### PR TITLE
fix(actor): correct SetFireNode vtable slot

### DIFF
--- a/include/RE/A/Actor.h
+++ b/include/RE/A/Actor.h
@@ -352,8 +352,8 @@ namespace RE
 		SKYRIM_REL_VR_VIRTUAL void                   SetActionComplete(bool a_set);                                                        // SE/AE 0x87, VR 0x88
 		SKYRIM_REL_VR_VIRTUAL void                   Disable();                                                                            // SE/AE 0x89, VR 0x8A
 		SKYRIM_REL_VR_VIRTUAL void                   ResetInventory(bool a_leveledOnly);                                                   // SE/AE 0x8A, VR 0x8B
-		SKYRIM_REL_VR_VIRTUAL NiNode*                GetFireNode();                                                                        // SE/AE 0x8C, VR 0x8D
-		SKYRIM_REL_VR_VIRTUAL void                   SetFireNode(NiNode* a_fireNode);                                                      // SE/AE 0x8D, VR 0x8E
+		SKYRIM_REL_VR_VIRTUAL NiNode*                GetFireNode();                                                                        // SE/AE 0x8B, VR 0x8D
+		SKYRIM_REL_VR_VIRTUAL void                   SetFireNode(NiNode* a_fireNode);                                                      // SE/AE 0x8C, VR 0x8E
 		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL bool     OnAddCellPerformQueueReference(TESObjectCELL& a_cell) const;                          // SE/AE 0x90, VR 0x91
 		SKYRIM_REL_VR_VIRTUAL void                   DoMoveToHigh();                                                                       // SE/AE 0x91, VR 0x92
 		SKYRIM_REL_VR_VIRTUAL void                   TryMoveToMiddleLow();                                                                 // SE/AE 0x92, VR 0x93

--- a/include/RE/A/Actor.h
+++ b/include/RE/A/Actor.h
@@ -352,8 +352,8 @@ namespace RE
 		SKYRIM_REL_VR_VIRTUAL void                   SetActionComplete(bool a_set);                                                        // SE/AE 0x87, VR 0x88
 		SKYRIM_REL_VR_VIRTUAL void                   Disable();                                                                            // SE/AE 0x89, VR 0x8A
 		SKYRIM_REL_VR_VIRTUAL void                   ResetInventory(bool a_leveledOnly);                                                   // SE/AE 0x8A, VR 0x8B
-		SKYRIM_REL_VR_VIRTUAL NiNode*                GetFireNode();                                                                        // SE/AE 0x8B, VR 0x8D
-		SKYRIM_REL_VR_VIRTUAL void                   SetFireNode(NiNode* a_fireNode);                                                      // SE/AE 0x8C, VR 0x8E
+		SKYRIM_REL_VR_VIRTUAL NiNode*                GetFireNode();                                                                        // SE/AE 0x8B, VR 0x8C
+		SKYRIM_REL_VR_VIRTUAL void                   SetFireNode(NiNode* a_fireNode);                                                      // SE/AE 0x8C, VR 0x8D
 		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL bool     OnAddCellPerformQueueReference(TESObjectCELL& a_cell) const;                          // SE/AE 0x90, VR 0x91
 		SKYRIM_REL_VR_VIRTUAL void                   DoMoveToHigh();                                                                       // SE/AE 0x91, VR 0x92
 		SKYRIM_REL_VR_VIRTUAL void                   TryMoveToMiddleLow();                                                                 // SE/AE 0x92, VR 0x93

--- a/include/RE/T/TESObjectREFR.h
+++ b/include/RE/T/TESObjectREFR.h
@@ -320,20 +320,21 @@ namespace RE
 			}
 		}
 #endif
-		SKYRIM_REL_VR_VIRTUAL void                      RemoveWeapon(BIPED_OBJECT equipIndex);          // 82 - { return; }
-		SKYRIM_REL_VR_VIRTUAL void                      Unk_83(void);                                   // 83 - { return; }
-		SKYRIM_REL_VR_VIRTUAL void                      SetObjectReference(TESBoundObject* a_object);   // 84 - sets flag 24 if the object has destructibles
-		SKYRIM_REL_VR_VIRTUAL void                      MoveHavok(bool a_forceRec);                     // 85
-		SKYRIM_REL_VR_VIRTUAL void                      GetLinearVelocity(NiPoint3& a_velocity) const;  // 86
-		SKYRIM_REL_VR_VIRTUAL void                      SetActionComplete(bool a_set);                  // 87 - { return; }
-		SKYRIM_REL_VR_VIRTUAL void                      SetMovementComplete(bool a_set);                // 89 - { return; }
-		SKYRIM_REL_VR_VIRTUAL void                      Disable();                                      // 8A
-		SKYRIM_REL_VR_VIRTUAL void                      ResetInventory(bool a_leveledOnly);             // 8B
-		SKYRIM_REL_VR_VIRTUAL void                      Unk_8C(void);                                   // 8C - real slot; checks a field at +0x430, conditionally calls cleanup
-		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL NiNode*     GetFireNode();                                  // 8D - { return 0; }
-		SKYRIM_REL_VR_VIRTUAL void                      SetFireNode(NiNode* a_fireNode);                // 8E - { return; }
-		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL NiAVObject* GetCurrent3D() const;                           // 8F - { return Get3D2(); }
-		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL Explosion*  AsExplosion();                                  // 90 - { return 0; }
+		SKYRIM_REL_VR_VIRTUAL void RemoveWeapon(BIPED_OBJECT equipIndex);          // 82 - { return; }
+		SKYRIM_REL_VR_VIRTUAL void Unk_83(void);                                   // 83 - { return; }
+		SKYRIM_REL_VR_VIRTUAL void SetObjectReference(TESBoundObject* a_object);   // 84 - sets flag 24 if the object has destructibles
+		SKYRIM_REL_VR_VIRTUAL void MoveHavok(bool a_forceRec);                     // 85
+		SKYRIM_REL_VR_VIRTUAL void GetLinearVelocity(NiPoint3& a_velocity) const;  // 86
+		SKYRIM_REL_VR_VIRTUAL void SetActionComplete(bool a_set);                  // 87 - { return; }
+		SKYRIM_REL_VR_VIRTUAL void SetMovementComplete(bool a_set);                // 89 - { return; }
+		SKYRIM_REL_VR_VIRTUAL void Disable();                                      // 8A
+		SKYRIM_REL_VR_VIRTUAL void ResetInventory(bool a_leveledOnly);             // 8B
+		// Getter/setter pair over AIProcess::middleHigh->weaponBone (MiddleHighProcessData+0x150):
+		// GetFireNode lazily computes and caches it, SetFireNode stores directly.
+		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL NiNode*     GetFireNode();                    // SE/AE 0x8B, VR 0x8D - { return 0; }
+		SKYRIM_REL_VR_VIRTUAL void                      SetFireNode(NiNode* a_fireNode);  // SE/AE 0x8C, VR 0x8E - { return; }
+		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL NiAVObject* GetCurrent3D() const;             // SE/AE 0x8D, VR 0x8F - { return Get3D2(); }
+		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL Explosion*  AsExplosion();                    // 90 - { return 0; }
 		// UNVERIFIED - unverified past this point (2026-07); slots need re-confirming against SkyrimVR.exe
 		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL Projectile*    AsProjectile();                                                                       // UNVERIFIED - { return 0; }
 		SKYRIM_REL_VR_VIRTUAL bool                         OnAddCellPerformQueueReference(TESObjectCELL& a_cell) const;                          // UNVERIFIED - { return true; }

--- a/include/RE/T/TESObjectREFR.h
+++ b/include/RE/T/TESObjectREFR.h
@@ -331,9 +331,9 @@ namespace RE
 		SKYRIM_REL_VR_VIRTUAL void ResetInventory(bool a_leveledOnly);             // 8B
 		// Getter/setter pair over AIProcess::middleHigh->weaponBone (MiddleHighProcessData+0x150):
 		// GetFireNode lazily computes and caches it, SetFireNode stores directly.
-		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL NiNode*     GetFireNode();                    // SE/AE 0x8B, VR 0x8D - { return 0; }
-		SKYRIM_REL_VR_VIRTUAL void                      SetFireNode(NiNode* a_fireNode);  // SE/AE 0x8C, VR 0x8E - { return; }
-		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL NiAVObject* GetCurrent3D() const;             // SE/AE 0x8D, VR 0x8F - { return Get3D2(); }
+		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL NiNode*     GetFireNode();                    // SE/AE 0x8B, VR 0x8C - { return 0; }
+		SKYRIM_REL_VR_VIRTUAL void                      SetFireNode(NiNode* a_fireNode);  // SE/AE 0x8C, VR 0x8D - { return; }
+		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL NiAVObject* GetCurrent3D() const;             // SE/AE 0x8D, VR 0x8E - { return Get3D2(); }
 		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL Explosion*  AsExplosion();                    // 90 - { return 0; }
 		// UNVERIFIED - unverified past this point (2026-07); slots need re-confirming against SkyrimVR.exe
 		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL Projectile*    AsProjectile();                                                                       // UNVERIFIED - { return 0; }

--- a/src/RE/A/Actor.cpp
+++ b/src/RE/A/Actor.cpp
@@ -1625,12 +1625,12 @@ namespace RE
 
 	NiNode* Actor::GetFireNode()
 	{
-		return RelocateVirtual<decltype(&Actor::GetFireNode)>(0x8B, 0x8D, this);
+		return RelocateVirtual<decltype(&Actor::GetFireNode)>(0x8B, 0x8C, this);
 	}
 
 	void Actor::SetFireNode(NiNode* a_fireNode)
 	{
-		RelocateVirtual<decltype(&Actor::SetFireNode)>(0x8C, 0x8E, this, a_fireNode);
+		RelocateVirtual<decltype(&Actor::SetFireNode)>(0x8C, 0x8D, this, a_fireNode);
 	}
 
 	bool Actor::OnAddCellPerformQueueReference(TESObjectCELL& a_cell) const

--- a/src/RE/A/Actor.cpp
+++ b/src/RE/A/Actor.cpp
@@ -1625,12 +1625,12 @@ namespace RE
 
 	NiNode* Actor::GetFireNode()
 	{
-		return RelocateVirtual<decltype(&Actor::GetFireNode)>(0x8C, 0x8D, this);
+		return RelocateVirtual<decltype(&Actor::GetFireNode)>(0x8B, 0x8D, this);
 	}
 
 	void Actor::SetFireNode(NiNode* a_fireNode)
 	{
-		RelocateVirtual<decltype(&Actor::SetFireNode)>(0x8D, 0x8E, this, a_fireNode);
+		RelocateVirtual<decltype(&Actor::SetFireNode)>(0x8C, 0x8E, this, a_fireNode);
 	}
 
 	bool Actor::OnAddCellPerformQueueReference(TESObjectCELL& a_cell) const

--- a/src/RE/T/TESObjectREFR.cpp
+++ b/src/RE/T/TESObjectREFR.cpp
@@ -1171,12 +1171,12 @@ namespace RE
 
 	NiNode* TESObjectREFR::GetFireNode()
 	{
-		return REL::RelocateVirtual<decltype(&TESObjectREFR::GetFireNode)>(0x8B, 0x8D, this);
+		return REL::RelocateVirtual<decltype(&TESObjectREFR::GetFireNode)>(0x8B, 0x8C, this);
 	}
 
 	void TESObjectREFR::SetFireNode(NiNode* a_fireNode)
 	{
-		REL::RelocateVirtual<decltype(&TESObjectREFR::SetFireNode)>(0x8C, 0x8E, this, a_fireNode);
+		REL::RelocateVirtual<decltype(&TESObjectREFR::SetFireNode)>(0x8C, 0x8D, this, a_fireNode);
 	}
 
 	NiAVObject* TESObjectREFR::GetCurrent3D() const

--- a/src/RE/T/TESObjectREFR.cpp
+++ b/src/RE/T/TESObjectREFR.cpp
@@ -1171,12 +1171,12 @@ namespace RE
 
 	NiNode* TESObjectREFR::GetFireNode()
 	{
-		return REL::RelocateVirtual<decltype(&TESObjectREFR::GetFireNode)>(0x8B, 0x8C, this);
+		return REL::RelocateVirtual<decltype(&TESObjectREFR::GetFireNode)>(0x8B, 0x8D, this);
 	}
 
 	void TESObjectREFR::SetFireNode(NiNode* a_fireNode)
 	{
-		REL::RelocateVirtual<decltype(&TESObjectREFR::SetFireNode)>(0x8C, 0x8D, this, a_fireNode);
+		REL::RelocateVirtual<decltype(&TESObjectREFR::SetFireNode)>(0x8C, 0x8E, this, a_fireNode);
 	}
 
 	NiAVObject* TESObjectREFR::GetCurrent3D() const


### PR DESCRIPTION
## Root cause

`TESObjectREFR` declared three virtuals — `Unk_8C`, `GetFireNode`, and a separate `SetFireNode` — for only two real vtable slots on SE/AE (`Unk_8C` and `GetFireNode` were also declared in the wrong relative order). The extra `SetFireNode` had no real slot of its own on non-cross-VR builds, where these are plain C++ virtuals (`SKYRIM_REL_VR_VIRTUAL` expands to bare `virtual`, no explicit index) — so it silently pushed every later virtual in this region one compiler-assigned slot high: `GetCurrent3D`, `AsExplosion`, `AsProjectile`, `OnAddCellPerformQueueReference`, ... all the way through `Actor::IsDead` (`0x99` → `0x9A`), which on flat SE/AE builds lands on `Actor::CreateAnimNoteReceiver` instead.

This is the underlying cause of #311 — `Actor::IsDead()` doesn't misbehave, it isn't being called at all on non-cross-VR builds. The stray extra bool argument is ignored, and the returned `BSAnimNoteReceiver*`'s low byte gets read back as the bool result, which is why it read `true` ("dead") for nearly every living actor.

## What `Unk_8C` actually is

Traced its target function: it writes into `AIProcess::middleHigh->weaponBone` (`MiddleHighProcessData+0x150`), the exact same field `GetFireNode` lazily computes and caches before returning. It's `SetFireNode` — a one-line public setter for the getter/setter pair `GetFireNode` already documents.

## Fix

- `include/RE/T/TESObjectREFR.h`: merged the three declarations into two, correctly ordered (`GetFireNode` then `SetFireNode`).
- `include/RE/A/Actor.h`: corrected the SE/AE slot-number comments (`0x8B`/`0x8C`, were `0x8C`/`0x8D`) — comment-only, `Actor`'s override slots follow the base class automatically once it's fixed there.
- `src/RE/A/Actor.cpp`, `src/RE/T/TESObjectREFR.cpp`: a second, independent bug in the same functions — the `SKYRIM_CROSS_VR` bodies had wrong/mutually-inconsistent hardcoded `RelocateVirtual` indices for `GetFireNode`/`SetFireNode`. Fixed to `GetFireNode(0x8B, 0x8D)` / `SetFireNode(0x8C, 0x8E)` in both files.

## Verification

All slot numbers (SE/AE `0x8B`–`0x91`, VR `0x8D`–`0x91`) confirmed directly against the real binaries — RTTI-derived vtable dumps plus decompiled function bodies matched by signature/behavior — on `SkyrimSE.exe` (1.5.97), `SkyrimSE.1170.exe` (1.6.1170), and `SkyrimVR.exe` (1.4.15).

Confirmed the fix closes the loop end-to-end: built ersh1/Precision#4 (the PR that reported #311) against this branch's `CommonLibSSE.lib`. Before the fix, both of Precision's `->IsDead()` call sites compiled to `MOV RAX,[RAX+0x4D0]` (slot `0x9A`, wrong). After the fix, rebuilding from the identical Precision source against this patched library, the exact same call sites compile to `MOV RAX,[RAX+0x4C8]` (slot `0x99`, correct) — no other change.

Fixes #311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fire-node access and update behavior across supported game editions.
  * Fixed virtual method mappings for standard, Anniversary, and VR builds.
  * Improved object 3D retrieval compatibility by aligning method dispatch behavior.
  * Removed an obsolete internal method entry to prevent mismatched calls and improve runtime stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->