### PR TITLE
fix(mistmenu): correct VR HMD/hand node field types

### DIFF
--- a/include/RE/M/MistMenu.h
+++ b/include/RE/M/MistMenu.h
@@ -114,13 +114,11 @@ namespace RE
 		};
 		static_assert(sizeof(VR_RUNTIME_DATA) == 0x58);
 
-		// VR-only: 3 live BSOpenVR HMD/hand node pointers, refreshed by UpdateVRControllerTransforms,
-		// which receives &GetRuntimeData() (this+0x68 on VR) as `this`, not MistMenu itself -- so
-		// these overlap RUNTIME_DATA::ambientColors[2]/[3], not MistMenu's own byte range directly.
+		// VR-only: overlaps RUNTIME_DATA::ambientColors[2]-[5], not free storage on VR.
 		struct VR_CONTROLLER_NODE_DATA
 		{
 			NiPointer<NiNode> hmdNode;       /* RUNTIME_DATA+20 = 88 */
-			std::byte         pad28[0x8];    /* RUNTIME_DATA+28 = 90 - ambientColors tail, untouched */
+			std::byte         pad28[0x8];    /* RUNTIME_DATA+28 = 90 */
 			NiPointer<NiNode> leftHandNode;  /* RUNTIME_DATA+30 = 98 */
 			NiPointer<NiNode> rightHandNode; /* RUNTIME_DATA+38 = A0 */
 		};
@@ -135,10 +133,8 @@ namespace RE
 		void               AdvanceMovie(float a_interval, std::uint32_t a_currentTime) override;  // 05
 		void               PostDisplay() override;                                                // 06
 
-#if defined(EXCLUSIVE_SKYRIM_VR)
-		// VR-only, called from PostDisplay; not bound (engine-invoked-only, no known consumer call site).
+		// VR-only, engine-called from PostDisplay; non-virtual, so unconditional declaration is ABI-safe.
 		void UpdateVRControllerTransforms();
-#endif
 
 		// override (MenuEventHandler)
 #ifndef SKYRIM_CROSS_VR

--- a/include/RE/M/MistMenu.h
+++ b/include/RE/M/MistMenu.h
@@ -114,12 +114,31 @@ namespace RE
 		};
 		static_assert(sizeof(VR_RUNTIME_DATA) == 0x58);
 
+		// VR-only: 3 live BSOpenVR HMD/hand node pointers, refreshed by UpdateVRControllerTransforms.
+		// Overlaps IMenu's generic VR tail (inputContext/pad24, unk30/unk34/menuName), which
+		// MistMenu specifically repurposes here instead. None is null-checked before the write.
+		struct VR_CONTROLLER_NODE_DATA
+		{
+			NiPointer<NiNode> hmdNode;       /* 20 */
+			std::byte         pad28[0x8];    /* 28 - IMenu::fxDelegate, untouched */
+			NiPointer<NiNode> leftHandNode;  /* 30 */
+			NiPointer<NiNode> rightHandNode; /* 38 */
+		};
+		static_assert(sizeof(VR_CONTROLLER_NODE_DATA) == 0x20);
+
+		VR_ONLY_POINTER_ACCESSOR(VR_CONTROLLER_NODE_DATA, GetVRControllerNodeData, 0x20);
+
 		~MistMenu() override;  // 00
 
 		// override (IMenu)
 		UI_MESSAGE_RESULTS ProcessMessage(UIMessage& a_message) override;                         // 04
 		void               AdvanceMovie(float a_interval, std::uint32_t a_currentTime) override;  // 05
 		void               PostDisplay() override;                                                // 06
+
+#if defined(EXCLUSIVE_SKYRIM_VR)
+		// VR-only, called from PostDisplay; not bound (engine-invoked-only, no known consumer call site).
+		void UpdateVRControllerTransforms();
+#endif
 
 		// override (MenuEventHandler)
 #ifndef SKYRIM_CROSS_VR

--- a/include/RE/M/MistMenu.h
+++ b/include/RE/M/MistMenu.h
@@ -114,19 +114,19 @@ namespace RE
 		};
 		static_assert(sizeof(VR_RUNTIME_DATA) == 0x58);
 
-		// VR-only: 3 live BSOpenVR HMD/hand node pointers, refreshed by UpdateVRControllerTransforms.
-		// Overlaps IMenu's generic VR tail (inputContext/pad24, unk30/unk34/menuName), which
-		// MistMenu specifically repurposes here instead. None is null-checked before the write.
+		// VR-only: 3 live BSOpenVR HMD/hand node pointers, refreshed by UpdateVRControllerTransforms,
+		// which receives &GetRuntimeData() (this+0x68 on VR) as `this`, not MistMenu itself -- so
+		// these overlap RUNTIME_DATA::ambientColors[2]/[3], not MistMenu's own byte range directly.
 		struct VR_CONTROLLER_NODE_DATA
 		{
-			NiPointer<NiNode> hmdNode;       /* 20 */
-			std::byte         pad28[0x8];    /* 28 - IMenu::fxDelegate, untouched */
-			NiPointer<NiNode> leftHandNode;  /* 30 */
-			NiPointer<NiNode> rightHandNode; /* 38 */
+			NiPointer<NiNode> hmdNode;       /* RUNTIME_DATA+20 = 88 */
+			std::byte         pad28[0x8];    /* RUNTIME_DATA+28 = 90 - ambientColors tail, untouched */
+			NiPointer<NiNode> leftHandNode;  /* RUNTIME_DATA+30 = 98 */
+			NiPointer<NiNode> rightHandNode; /* RUNTIME_DATA+38 = A0 */
 		};
 		static_assert(sizeof(VR_CONTROLLER_NODE_DATA) == 0x20);
 
-		VR_ONLY_POINTER_ACCESSOR(VR_CONTROLLER_NODE_DATA, GetVRControllerNodeData, 0x20);
+		VR_ONLY_POINTER_ACCESSOR(VR_CONTROLLER_NODE_DATA, GetVRControllerNodeData, 0x88);
 
 		~MistMenu() override;  // 00
 


### PR DESCRIPTION
## Summary
- `MistMenu`'s `hmdNode`/`leftHandNode`/`rightHandNode` cached avatar-node pointers were undocumented and misdeclared (the local struct DB and `IMenu.h`'s generic VR tail called them `inputContext`/`unk30`/`menuName`), reused from `RE::IMenu`'s byte range in a way that only actually applies to `MistMenu`.
- Field identity confirmed via live memory read (vtable-matched to `NiNode`), static disassembly of the writing function, and finally the literal `NiAVObject::SetName` calls in the construction function (`"HMD Node"`/`"Left Hand Node"`/`"Right Hand Node"`).
- Adds `MistMenu::VR_CONTROLLER_NODE_DATA` + `GetVRControllerNodeData()` (`VR_ONLY_POINTER_ACCESSOR`), and declares (unbound — no known consumer call site) `MistMenu::UpdateVRControllerTransforms()`, which crashes on a null `hmdNode` in the wild (real vanilla bug, guard fix separately in progress for EngineFixes).
- Does not touch `IMenu.h`'s shared VR tail — `menuName`/`unk30` are genuinely used elsewhere (`WorldSpaceMenu`), so this is scoped entirely to `MistMenu`'s own overlapping declaration.
- Second commit corrects an offset bug found while verifying: `UpdateVRControllerTransforms` actually receives `&GetRuntimeData()` (`this+0x68` on VR), not `MistMenu*` itself, so the accessor's true absolute offset is `0x88`/`0x98`/`0xA0`, not `0x20`.

## Test plan
- [x] `debug-clang-cl-vcpkg-se` builds clean
- [x] `debug-clang-cl-vcpkg-ae` builds clean
- [x] `debug-clang-cl-vcpkg-vr` builds clean
- [x] `debug-clang-cl-vcpkg-all` (`SKYRIM_CROSS_VR`) builds clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VR support for accessing the headset and left/right controller nodes.
  * Added functionality to update VR controller transforms during display processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->