### PR TITLE
build(cmake): pass list name, not value, to LENGTH

### DIFF
--- a/cmake/CommonLibSSE.cmake
+++ b/cmake/CommonLibSSE.cmake
@@ -124,7 +124,7 @@ function(target_commonlibsse_properties TARGET)
             set(commonlibsse_plugin_compatibility "SKSE::VersionIndependence::AddressLibrary")
         endif()
     else()
-        list(LENGTH ${ADD_COMMONLIBSSE_PLUGIN_COMPATIBLE_RUNTIMES} commonlibsse_plugin_compatibility_count)
+        list(LENGTH ADD_COMMONLIBSSE_PLUGIN_COMPATIBLE_RUNTIMES commonlibsse_plugin_compatibility_count)
 
         if(commonlibsse_plugin_compatibility_count GREATER 16)
             message(FATAL_ERROR "No more than 16 version numbers can be provided for COMPATIBLE_RUNTIMES.")


### PR DESCRIPTION
## Summary
- `list(LENGTH <listVar> <out>)` needs the list variable's **name**, not its expanded value. `list(LENGTH ${ADD_COMMONLIBSSE_PLUGIN_COMPATIBLE_RUNTIMES} ...)` inlines each list element as a separate argument once `COMPATIBLE_RUNTIMES` has more than one entry, breaking configuration with `list sub-command LENGTH requires two arguments`.
- Fix: drop the `${}` so `list()` receives the variable name directly.
- Reproduced the exact reported error with a standalone 3-element test list, confirmed the fix resolves it cleanly.

Closes #314

## Test plan
- [x] Standalone repro: `list(LENGTH ${MY_LIST} ...)` with a 3-element list reproduces `list sub-command LENGTH requires two arguments`
- [x] Same repro with the fix (`list(LENGTH MY_LIST ...)`) configures cleanly and reports the correct count
- [x] `CommonLibSSE` library target still builds clean on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a build configuration check to reliably validate compatible runtime settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->