### PR TITLE
build: set sysroot flags for RC compilation

### DIFF
--- a/cmake/toolchain-linux-clangcl.cmake
+++ b/cmake/toolchain-linux-clangcl.cmake
@@ -36,14 +36,16 @@ endif()
 # /EHsc belongs here rather than in the consumer's flags because vcpkg
 # builds each dependency in an isolated configure that inherits only this
 # file, and clang-cl otherwise defaults to exceptions disabled.
+set(_xwin_compile_flags "--target=x86_64-pc-windows-msvc /winsysroot${_xwin_sysroot}")
+
 if(NOT CMAKE_CXX_FLAGS MATCHES "winsysroot")
-    set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} --target=x86_64-pc-windows-msvc /winsysroot${_xwin_sysroot}" CACHE STRING "" FORCE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --target=x86_64-pc-windows-msvc /winsysroot${_xwin_sysroot} /EHsc" CACHE STRING "" FORCE)
+    set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} ${_xwin_compile_flags}" CACHE STRING "" FORCE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_xwin_compile_flags} /EHsc" CACHE STRING "" FORCE)
     set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} /winsysroot:${_xwin_sysroot}" CACHE STRING "" FORCE)
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /winsysroot:${_xwin_sysroot}" CACHE STRING "" FORCE)
 endif()
 
 # CMAKE_RC_FLAGS is separate from CMAKE_C_FLAGS/CMAKE_CXX_FLAGS; needs its own sysroot guard or winres.h etc. fail to resolve.
 if(NOT CMAKE_RC_FLAGS MATCHES "winsysroot")
-    set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} --target=x86_64-pc-windows-msvc /winsysroot${_xwin_sysroot}" CACHE STRING "" FORCE)
+    set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} ${_xwin_compile_flags}" CACHE STRING "" FORCE)
 endif()

--- a/cmake/toolchain-linux-clangcl.cmake
+++ b/cmake/toolchain-linux-clangcl.cmake
@@ -42,3 +42,8 @@ if(NOT CMAKE_CXX_FLAGS MATCHES "winsysroot")
     set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} /winsysroot:${_xwin_sysroot}" CACHE STRING "" FORCE)
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /winsysroot:${_xwin_sysroot}" CACHE STRING "" FORCE)
 endif()
+
+# CMAKE_RC_FLAGS is separate from CMAKE_C_FLAGS/CMAKE_CXX_FLAGS; needs its own sysroot guard or winres.h etc. fail to resolve.
+if(NOT CMAKE_RC_FLAGS MATCHES "winsysroot")
+    set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} --target=x86_64-pc-windows-msvc /winsysroot${_xwin_sysroot}" CACHE STRING "" FORCE)
+endif()


### PR DESCRIPTION
## Summary
CMake's built-in RC-compile rule (`cmake_llvm_rc`) preprocesses the `.rc` file via `clang-cl` in `-E` mode using `CMAKE_RC_FLAGS`, a separate variable from `CMAKE_C_FLAGS`/`CMAKE_CXX_FLAGS` this toolchain file already sets for the Linux-host cross-compile support (landed in #302 / v6.6.0). Without this, a resource file that includes Windows SDK headers (e.g. `winres.h`) fails with `file not found` since the preprocessing step never gets the sysroot's include paths.

RC is commonly `enable_language()`d well after C/CXX (only once a target with a `.rc` source is actually declared, in a consumer's own build), by which point the existing C/CXX guard has already gone false since it re-checks `CMAKE_CXX_FLAGS` for the `winsysroot` marker. So this needs its own independent guard rather than reusing the C/CXX one, or it silently never runs.

## Test plan
- [x] Verified against a downstream consumer (open-shaders' `Linux-ClangCL` cross-compile preset, which embeds a `version.rc` resource) — this was the last missing piece before a full `cmake --build` succeeded end-to-end.