### PR TITLE
docs(linux): add debian

### DIFF
--- a/examples/linux-cross-compile/README.md
+++ b/examples/linux-cross-compile/README.md
@@ -8,29 +8,45 @@ sysroot obtained with [`xwin`](https://github.com/Jake-Shadle/xwin).
 ## One-time setup
 
 ```bash
-# Toolchain
-sudo pacman -S clang lld llvm cmake ninja rust git   # adjust for your distro
+# Toolchain adjust for your distro
+# Arch
+sudo pacman -S clang lld llvm cmake ninja rust git
+
+# Debian
+sudo apt-get install clang lld llvm cmake ninja-build rustup git
+rustup default stable
 
 # Wine + llvm-mingw: needed only to build/run the fxc2 shader-compile
 # stand-in (see below), not for the main build itself.
+# Arch
 sudo pacman -S wine llvm-mingw
+
+# Debian; Use manual install of llvm-mingw.
+sudo apt-get install wine
+
+# Manual llvm-mingw install.
+cd /tmp
+wget https://github.com/mstorsjo/llvm-mingw/releases/download/20260826/llvm-mingw-20260826-ucrt-ubuntu-22.04-x86_64.tar.xz
+tar -xf llvm-mingw-*.tar.xz
+sudo mkdir /opt/llvm-mingw/
+sudo mv llvm-mingw-*/* /opt/llvm-mingw/
+export LLVM_MINGW_BIN=/opt/llvm-mingw/bin
 
 # xwin, pinned for reproducibility
 cargo install xwin --version 0.10.0 --locked
 export PATH="$HOME/.cargo/bin:$PATH"
 
-# Windows SDK + MSVC CRT sysroot. Both flags are required: without
-# --use-winsysroot-style, /winsysroot finds nothing; without
-# --preserve-ms-arch-notation, folders are named x86_64 instead of x64
-# and lld-link's auto-search fails.
+# Windows SDK + MSVC CRT sysroot. Both flags are required:
+# without --use-winsysroot-style, /winsysroot finds nothing;
+# without --preserve-ms-arch-notation, folders are named x86_64 instead of x64 and lld-link's auto-search fails.
 mkdir -p ~/xwin-cache ~/xwin-out
-xwin --accept-license --cache-dir ~/xwin-cache splat \
+xwin --accept-license --http-retry 10 --cache-dir ~/xwin-cache splat \
   --output ~/xwin-out --include-debug-libs \
   --use-winsysroot-style --preserve-ms-arch-notation
 
 # vcpkg
 git clone https://github.com/microsoft/vcpkg ~/.local/share/vcpkg
-~/.local/share/vcpkg/bootstrap-vcpkg.sh
+~/.local/share/vcpkg/bootstrap-vcpkg.sh -disableMetrics
 export VCPKG_ROOT=~/.local/share/vcpkg
 ```
 

--- a/examples/linux-cross-compile/README.md
+++ b/examples/linux-cross-compile/README.md
@@ -12,7 +12,7 @@ sysroot obtained with [`xwin`](https://github.com/Jake-Shadle/xwin).
 # Arch
 sudo pacman -S clang lld llvm cmake ninja rust git
 
-# Debian
+# Debian 13 "Trixie"
 sudo apt-get install clang lld llvm cmake ninja-build rustup git
 rustup default stable
 
@@ -22,14 +22,14 @@ rustup default stable
 sudo pacman -S wine llvm-mingw
 
 # Debian; Use manual install of llvm-mingw.
-sudo apt-get install wine
+sudo apt-get install wine wget
 
-# Manual llvm-mingw install.
+# Manual llvm-mingw install for Distros that don't have a native package.
 cd /tmp
 wget https://github.com/mstorsjo/llvm-mingw/releases/download/20260826/llvm-mingw-20260826-ucrt-ubuntu-22.04-x86_64.tar.xz
-tar -xf llvm-mingw-*.tar.xz
+tar -xf llvm-mingw-20260826-ucrt-ubuntu-22.04-x86_64.tar.xz
 sudo mkdir /opt/llvm-mingw/
-sudo mv llvm-mingw-*/* /opt/llvm-mingw/
+sudo mv llvm-mingw-20260826-ucrt-ubuntu-22.04-x86_64/* /opt/llvm-mingw/
 export LLVM_MINGW_BIN=/opt/llvm-mingw/bin
 
 # xwin, pinned for reproducibility


### PR DESCRIPTION
Add docs fo debian install and manual llvm-mingw install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux cross-compilation setup instructions for Arch and Debian distributions.
  * Added Debian guidance for installing the LLVM MinGW toolchain manually.
  * Improved retry handling for sysroot downloads.
  * Disabled metrics during vcpkg bootstrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->