### PR TITLE
refactor(d3d11): route ID3D11 through REX::W32

### DIFF
--- a/include/RE/N/NiSkinPartition.h
+++ b/include/RE/N/NiSkinPartition.h
@@ -4,22 +4,22 @@
 #include "RE/N/NiGeometryData.h"
 #include "RE/N/NiObject.h"
 #include "RE/V/VertexDesc.h"
+#include <REX/W32/D3D11.h>
 
 namespace RE
 {
-	struct ID3D11Buffer;
 
 	namespace BSGraphics
 	{
 		struct TriShape
 		{
-			ID3D11Buffer*          vertexBuffer;   // 00
-			ID3D11Buffer*          indexBuffer;    // 08
-			BSGraphics::VertexDesc vertexDesc;     // 10
-			volatile std::uint32_t refCount;       // 18
-			std::uint32_t          pad1C;          // 1C
-			std::uint8_t*          rawVertexData;  // 20
-			std::uint16_t*         rawIndexData;   // 28
+			REX::W32::ID3D11Buffer* vertexBuffer;   // 00
+			REX::W32::ID3D11Buffer* indexBuffer;    // 08
+			BSGraphics::VertexDesc  vertexDesc;     // 10
+			volatile std::uint32_t  refCount;       // 18
+			std::uint32_t           pad1C;          // 1C
+			std::uint8_t*           rawVertexData;  // 20
+			std::uint16_t*          rawIndexData;   // 28
 		};
 		static_assert(sizeof(TriShape) == 0x30);
 	}

--- a/include/RE/N/NiSourceTexture.h
+++ b/include/RE/N/NiSourceTexture.h
@@ -2,9 +2,7 @@
 
 #include "RE/N/NiSmartPointer.h"
 #include "RE/N/NiTexture.h"
-
-struct ID3D11Resource;
-struct ID3D11UnorderedAccessView;
+#include <REX/W32/D3D11.h>
 
 namespace RE
 {
@@ -13,16 +11,16 @@ namespace RE
 		class Texture
 		{
 		public:
-			ID3D11Resource*            texture;       // 00 - can be ID3D11Texture1D/ID3D11Texture2D/ID3D11Texture3D
-			ID3D11UnorderedAccessView* UAV;           // 08
-			ID3D11ShaderResourceView*  resourceView;  // 10
-			uint16_t                   height;        // 18
-			uint16_t                   width;         // 1A
-			uint8_t                    mips;          // 1C
-			uint8_t                    format;        // 1D
-			uint16_t                   unk1E;         // 1E
-			std::uint32_t              refCount;      // 20
-			std::uint32_t              pad24;         // 24
+			REX::W32::ID3D11Resource*            texture;       // 00 - can be ID3D11Texture1D/ID3D11Texture2D/ID3D11Texture3D
+			REX::W32::ID3D11UnorderedAccessView* UAV;           // 08
+			REX::W32::ID3D11ShaderResourceView*  resourceView;  // 10
+			uint16_t                             height;        // 18
+			uint16_t                             width;         // 1A
+			uint8_t                              mips;          // 1C
+			uint8_t                              format;        // 1D
+			uint16_t                             unk1E;         // 1E
+			std::uint32_t                        refCount;      // 20
+			std::uint32_t                        pad24;         // 24
 		};
 		static_assert(sizeof(Texture) == 0x28);
 

--- a/include/RE/N/NiTexture.h
+++ b/include/RE/N/NiTexture.h
@@ -3,9 +3,7 @@
 #include "RE/B/BSFixedString.h"
 #include "RE/N/NiObject.h"
 #include "RE/N/NiSmartPointer.h"
-
-struct ID3D11Texture2D;
-struct ID3D11ShaderResourceView;
+#include <REX/W32/D3D11.h>
 
 namespace RE
 {
@@ -71,16 +69,16 @@ namespace RE
 			RendererData(std::uint16_t width, std::uint16_t height) noexcept :
 				width(width), height(height) {}
 
-			ID3D11Texture2D*          texture{ nullptr };       // 00
-			std::uint64_t             unk08{ 0 };               // 08
-			ID3D11ShaderResourceView* resourceView{ nullptr };  // 10
-			std::uint16_t             width;                    // 18
-			std::uint16_t             height;                   // 1A
-			std::uint8_t              unk1C{ 1 };               // 1C
-			std::uint8_t              unk1D{ 0x1C };            // 1D
-			std::uint16_t             unk1E{ 0 };               // 1E
-			std::uint32_t             unk20{ 1 };               // 20
-			std::uint32_t             unk24{ 0x130012 };        // 24
+			REX::W32::ID3D11Texture2D*          texture{ nullptr };       // 00
+			std::uint64_t                       unk08{ 0 };               // 08
+			REX::W32::ID3D11ShaderResourceView* resourceView{ nullptr };  // 10
+			std::uint16_t                       width;                    // 18
+			std::uint16_t                       height;                   // 1A
+			std::uint8_t                        unk1C{ 1 };               // 1C
+			std::uint8_t                        unk1D{ 0x1C };            // 1D
+			std::uint16_t                       unk1E{ 0 };               // 1E
+			std::uint32_t                       unk20{ 1 };               // 20
+			std::uint32_t                       unk24{ 0x130012 };        // 24
 
 			TES_HEAP_REDEFINE_NEW();
 		};

--- a/include/RE/R/RenderTargetData.h
+++ b/include/RE/R/RenderTargetData.h
@@ -1,10 +1,6 @@
 #pragma once
 
-struct ID3D11DepthStencilView;
-struct ID3D11RenderTargetView;
-struct ID3D11ShaderResourceView;
-struct ID3D11Texture2D;
-struct ID3D11UnorderedAccessView;
+#include <REX/W32/D3D11.h>
 
 namespace RE
 {
@@ -12,30 +8,30 @@ namespace RE
 	{
 		struct RenderTargetData
 		{
-			ID3D11Texture2D*           texture;      // 00
-			ID3D11Texture2D*           textureCopy;  // 08
-			ID3D11RenderTargetView*    RTV;          // 10 - for "Texture"
-			ID3D11ShaderResourceView*  SRV;          // 18 - for Texture"
-			ID3D11ShaderResourceView*  SRVCopy;      // 20 - for "TextureCopy"
-			ID3D11UnorderedAccessView* UAV;          // 28 - for "Texture"
+			REX::W32::ID3D11Texture2D*           texture;      // 00
+			REX::W32::ID3D11Texture2D*           textureCopy;  // 08
+			REX::W32::ID3D11RenderTargetView*    RTV;          // 10 - for "Texture"
+			REX::W32::ID3D11ShaderResourceView*  SRV;          // 18 - for Texture"
+			REX::W32::ID3D11ShaderResourceView*  SRVCopy;      // 20 - for "TextureCopy"
+			REX::W32::ID3D11UnorderedAccessView* UAV;          // 28 - for "Texture"
 		};
 		static_assert(sizeof(RenderTargetData) == 0x30);
 
 		struct DepthStencilData
 		{
-			ID3D11Texture2D*          texture;           // 00
-			ID3D11DepthStencilView*   views[8];          // 08
-			ID3D11DepthStencilView*   readOnlyViews[8];  // 48
-			ID3D11ShaderResourceView* depthSRV;          // 88
-			ID3D11ShaderResourceView* stencilSRV;        // 90
+			REX::W32::ID3D11Texture2D*          texture;           // 00
+			REX::W32::ID3D11DepthStencilView*   views[8];          // 08
+			REX::W32::ID3D11DepthStencilView*   readOnlyViews[8];  // 48
+			REX::W32::ID3D11ShaderResourceView* depthSRV;          // 88
+			REX::W32::ID3D11ShaderResourceView* stencilSRV;        // 90
 		};
 		static_assert(sizeof(DepthStencilData) == 0x98);
 
 		struct CubemapRenderTargetData
 		{
-			ID3D11Texture2D*          texture;         // 00
-			ID3D11RenderTargetView*   cubeSideRTV[6];  // 08
-			ID3D11ShaderResourceView* SRV;             // 38
+			REX::W32::ID3D11Texture2D*          texture;         // 00
+			REX::W32::ID3D11RenderTargetView*   cubeSideRTV[6];  // 08
+			REX::W32::ID3D11ShaderResourceView* SRV;             // 38
 		};
 		static_assert(sizeof(CubemapRenderTargetData) == 0x40);
 

--- a/include/RE/R/RendererShadowState.h
+++ b/include/RE/R/RendererShadowState.h
@@ -5,7 +5,7 @@
 #include "RE\T\TextureAddressModes.h"
 #include "RE\T\TextureFilterModes.h"
 
-#include <d3d11.h>
+#include <REX/W32/D3D11.h>
 
 // see https://github.com/Nukem9/SkyrimSETest/blob/master/skyrim64_test/src/patches/TES/BSGraphics/BSGraphicsRenderer.h
 namespace RE
@@ -93,54 +93,54 @@ namespace RE
 #pragma warning(disable: 4324)  // ignore warning about padded due to alignment from DirectX datatypes (e.g., XMVECTOR, XMMATRIX).
 			struct FLAT_RUNTIME_DATA
 			{
-#define FLAT_RUNTIME_DATA_CONTENT                                                                                                                                 \
-	REX::EnumSet<ShaderFlags, uint32_t>        stateUpdateFlags;                                            /* 00 Flags +0x0  0xFFFFFFFF; global state updates */ \
-	uint32_t                                   PSResourceModifiedBits;                                      /* 04 Flags +0x4  0xFFFF */                           \
-	uint32_t                                   PSSamplerModifiedBits;                                       /* 08 Flags +0x8  0xFFFF */                           \
-	uint32_t                                   CSResourceModifiedBits;                                      /* 0c Flags +0xC  0xFFFF */                           \
-	uint32_t                                   CSSamplerModifiedBits;                                       /* 10 Flags +0x10 0xFFFF */                           \
-	uint32_t                                   CSUAVModifiedBits;                                           /* 14 Flags +0x14 0xFF */                             \
-	RENDER_TARGET                              renderTargets[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT];       /* 18, VR 20 */                                       \
-	uint32_t                                   depthStencil;                                                /* 38, VR 40 - Index */                               \
-	uint32_t                                   depthStencilSlice;                                           /* 3c, VR 44 Index */                                 \
-	uint32_t                                   cubeMapRenderTarget;                                         /* 40, VR 48 = Index */                               \
-	uint32_t                                   cubeMapRenderTargetView;                                     /* 44, VR 4c Index */                                 \
-	SetRenderTargetMode                        setRenderTargetMode[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT]; /* 48, VR 50 */                                       \
-	SetRenderTargetMode                        setDepthStencilMode;                                         /* 68, VR 70 */                                       \
-	SetRenderTargetMode                        setCubeMapRenderTargetMode;                                  /* 6c, VR 74 */                                       \
-	D3D11_VIEWPORT                             viewPort;                                                    /* 70, VR 78 */                                       \
-	DepthStencilDepthMode                      depthStencilDepthMode;                                       /* 88, VR 90 */                                       \
-	DepthStencilDepthMode                      depthStencilDepthModePrevious;                               /* 8c, VR 94 - also some kind of mode */              \
-	uint32_t                                   depthStencilStencilMode;                                     /* 90, VR 98 */                                       \
-	uint32_t                                   stencilRef;                                                  /* 94, VR 9c */                                       \
-	uint32_t                                   rasterStateFillMode;                                         /* 98, VR a0 */                                       \
-	uint32_t                                   rasterStateCullMode;                                         /* 9c, VR a4 */                                       \
-	uint32_t                                   rasterStateDepthBiasMode;                                    /* a0, VR a8 */                                       \
-	uint32_t                                   rasterStateScissorMode;                                      /* a4, VR ac */                                       \
-	uint32_t                                   alphaBlendMode;                                              /* a8, VR b0 */                                       \
-	uint32_t                                   alphaBlendAlphaToCoverage;                                   /* ac, VR b4 */                                       \
-	uint32_t                                   alphaBlendWriteMode;                                         /* b0, VR b8 */                                       \
-	bool                                       alphaTestEnabled;                                            /* b4, VR BC */                                       \
-	float                                      alphaTestRef;                                                /* b8, VR C0 */                                       \
-	REX::EnumSet<TextureAddressMode, uint32_t> PSTextureAddressMode[16];                                    /* bc, VR c4 */                                       \
-	REX::EnumSet<TextureFilterMode, uint32_t>  PSTextureFilterMode[16];                                     /* fc, VR 104 */                                      \
-	ID3D11ShaderResourceView*                  PSTexture[16];                                               /* 140, VR 148 */                                     \
-	REX::EnumSet<TextureAddressMode, uint32_t> CSTextureAddressMode[16];                                    /* 1c0, VR 1c8 */                                     \
-	REX::EnumSet<TextureFilterMode, uint32_t>  CSTextureFilterMode[16];                                     /* 200, VR 208 */                                     \
-	ID3D11ShaderResourceView*                  CSTexture[16];                                               /* 240, VR 248 */                                     \
-	uint32_t                                   CSTextureMinLodMode[16];                                     /* 2c0, VR 2C8 */                                     \
-	ID3D11UnorderedAccessView*                 CSUAV[8];                                                    /* 300, VR 308 */                                     \
-	uint64_t                                   vertexDesc;                                                  /* 340, VR 388 only? */                               \
-	VertexShader*                              currentVertexShader;                                         /* 348, VR 390 */                                     \
-	PixelShader*                               currentPixelShader;                                          /* 350, VR 398 */                                     \
-	D3D11_PRIMITIVE_TOPOLOGY                   topology;                                                    /* 358, VR 3A0 */                                     \
-	EYE_POSITION<NiPoint3>                     posAdjust;                                                   /* 35c, VR 3A4 */                                     \
-	EYE_POSITION<NiPoint3>                     previousPosAdjust;                                           /* 368, VR 3BC */                                     \
-	EYE_POSITION<ViewData>                     cameraData;                                                  /* 380, VR 3E0 - size of each is 250 */               \
-	uint32_t                                   alphaBlendModeExtra;                                         /* 5d0, VR 88c */                                     \
-	float                                      viewNear;                                                    /* 5d4, VR 884 */                                     \
-	float                                      viewFar;                                                     /* 5d8, VR 888 */                                     \
-	uint32_t                                   unk5dc;                                                      /* 5dc */
+#define FLAT_RUNTIME_DATA_CONTENT                                                                                                                                           \
+	REX::EnumSet<ShaderFlags, uint32_t>        stateUpdateFlags;                                                      /* 00 Flags +0x0  0xFFFFFFFF; global state updates */ \
+	uint32_t                                   PSResourceModifiedBits;                                                /* 04 Flags +0x4  0xFFFF */                           \
+	uint32_t                                   PSSamplerModifiedBits;                                                 /* 08 Flags +0x8  0xFFFF */                           \
+	uint32_t                                   CSResourceModifiedBits;                                                /* 0c Flags +0xC  0xFFFF */                           \
+	uint32_t                                   CSSamplerModifiedBits;                                                 /* 10 Flags +0x10 0xFFFF */                           \
+	uint32_t                                   CSUAVModifiedBits;                                                     /* 14 Flags +0x14 0xFF */                             \
+	RENDER_TARGET                              renderTargets[REX::W32::D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT];       /* 18, VR 20 */                                       \
+	uint32_t                                   depthStencil;                                                          /* 38, VR 40 - Index */                               \
+	uint32_t                                   depthStencilSlice;                                                     /* 3c, VR 44 Index */                                 \
+	uint32_t                                   cubeMapRenderTarget;                                                   /* 40, VR 48 = Index */                               \
+	uint32_t                                   cubeMapRenderTargetView;                                               /* 44, VR 4c Index */                                 \
+	SetRenderTargetMode                        setRenderTargetMode[REX::W32::D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT]; /* 48, VR 50 */                                       \
+	SetRenderTargetMode                        setDepthStencilMode;                                                   /* 68, VR 70 */                                       \
+	SetRenderTargetMode                        setCubeMapRenderTargetMode;                                            /* 6c, VR 74 */                                       \
+	REX::W32::D3D11_VIEWPORT                   viewPort;                                                              /* 70, VR 78 */                                       \
+	DepthStencilDepthMode                      depthStencilDepthMode;                                                 /* 88, VR 90 */                                       \
+	DepthStencilDepthMode                      depthStencilDepthModePrevious;                                         /* 8c, VR 94 - also some kind of mode */              \
+	uint32_t                                   depthStencilStencilMode;                                               /* 90, VR 98 */                                       \
+	uint32_t                                   stencilRef;                                                            /* 94, VR 9c */                                       \
+	uint32_t                                   rasterStateFillMode;                                                   /* 98, VR a0 */                                       \
+	uint32_t                                   rasterStateCullMode;                                                   /* 9c, VR a4 */                                       \
+	uint32_t                                   rasterStateDepthBiasMode;                                              /* a0, VR a8 */                                       \
+	uint32_t                                   rasterStateScissorMode;                                                /* a4, VR ac */                                       \
+	uint32_t                                   alphaBlendMode;                                                        /* a8, VR b0 */                                       \
+	uint32_t                                   alphaBlendAlphaToCoverage;                                             /* ac, VR b4 */                                       \
+	uint32_t                                   alphaBlendWriteMode;                                                   /* b0, VR b8 */                                       \
+	bool                                       alphaTestEnabled;                                                      /* b4, VR BC */                                       \
+	float                                      alphaTestRef;                                                          /* b8, VR C0 */                                       \
+	REX::EnumSet<TextureAddressMode, uint32_t> PSTextureAddressMode[16];                                              /* bc, VR c4 */                                       \
+	REX::EnumSet<TextureFilterMode, uint32_t>  PSTextureFilterMode[16];                                               /* fc, VR 104 */                                      \
+	REX::W32::ID3D11ShaderResourceView*        PSTexture[16];                                                         /* 140, VR 148 */                                     \
+	REX::EnumSet<TextureAddressMode, uint32_t> CSTextureAddressMode[16];                                              /* 1c0, VR 1c8 */                                     \
+	REX::EnumSet<TextureFilterMode, uint32_t>  CSTextureFilterMode[16];                                               /* 200, VR 208 */                                     \
+	REX::W32::ID3D11ShaderResourceView*        CSTexture[16];                                                         /* 240, VR 248 */                                     \
+	uint32_t                                   CSTextureMinLodMode[16];                                               /* 2c0, VR 2C8 */                                     \
+	REX::W32::ID3D11UnorderedAccessView*       CSUAV[8];                                                              /* 300, VR 308 */                                     \
+	uint64_t                                   vertexDesc;                                                            /* 340, VR 388 only? */                               \
+	VertexShader*                              currentVertexShader;                                                   /* 348, VR 390 */                                     \
+	PixelShader*                               currentPixelShader;                                                    /* 350, VR 398 */                                     \
+	REX::W32::D3D11_PRIMITIVE_TOPOLOGY         topology;                                                              /* 358, VR 3A0 */                                     \
+	EYE_POSITION<NiPoint3>                     posAdjust;                                                             /* 35c, VR 3A4 */                                     \
+	EYE_POSITION<NiPoint3>                     previousPosAdjust;                                                     /* 368, VR 3BC */                                     \
+	EYE_POSITION<ViewData>                     cameraData;                                                            /* 380, VR 3E0 - size of each is 250 */               \
+	uint32_t                                   alphaBlendModeExtra;                                                   /* 5d0, VR 88c */                                     \
+	float                                      viewNear;                                                              /* 5d4, VR 884 */                                     \
+	float                                      viewFar;                                                               /* 5d8, VR 888 */                                     \
+	uint32_t                                   unk5dc;                                                                /* 5dc */
                 FLAT_RUNTIME_DATA_CONTENT;
 			};
 			static_assert(sizeof(FLAT_RUNTIME_DATA) == 0x5e0);
@@ -176,60 +176,60 @@ namespace RE
 
 			struct VR_RUNTIME_DATA
 			{
-#define VR_RUNTIME_DATA_CONTENT                                                                                                                                                                        \
-	REX::EnumSet<ShaderFlags, uint32_t>        stateUpdateFlags;                                            /* 00 Flags +0x0  0xFFFFFFFF; global state updates */                                      \
-	uint32_t                                   PSResourceModifiedBits;                                      /* 04 Flags +0x4  0xFFFF */                                                                \
-	uint32_t                                   PSSamplerModifiedBits;                                       /* 08 Flags +0x8  0xFFFF */                                                                \
-	uint32_t                                   CSResourceModifiedBits;                                      /* 0c Flags +0xC  0xFFFF */                                                                \
-	uint32_t                                   CSSamplerModifiedBits;                                       /* 10 Flags +0x10 0xFFFF */                                                                \
-	uint32_t                                   CSUAVModifiedBits;                                           /* 14 Flags +0x14 0xFF */                                                                  \
-	uint32_t                                   OMUAVModifiedBits;                                           /* 18 Flags +0x18 0xFF VR Only  */                                                         \
-	uint32_t                                   SRVModifiedBits;                                             /* 1c Flags +0x1C 0xFF VR Only  */                                                         \
-	RENDER_TARGET                              renderTargets[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT];       /* 18, VR 20 */                                                                            \
-	uint32_t                                   depthStencil;                                                /* 38, VR 40 - Index */                                                                    \
-	uint32_t                                   depthStencilSlice;                                           /* 3c, VR 44 Index */                                                                      \
-	uint32_t                                   cubeMapRenderTarget;                                         /* 40, VR 48 = Index */                                                                    \
-	uint32_t                                   cubeMapRenderTargetView;                                     /* 44, VR 4c Index */                                                                      \
-	SetRenderTargetMode                        setRenderTargetMode[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT]; /* 48, VR 50 */                                                                            \
-	SetRenderTargetMode                        setDepthStencilMode;                                         /* 68, VR 70 */                                                                            \
-	SetRenderTargetMode                        setCubeMapRenderTargetMode;                                  /* 6c, VR 74 */                                                                            \
-	D3D11_VIEWPORT                             viewPort;                                                    /* 70, VR 78 */                                                                            \
-	DepthStencilDepthMode                      depthStencilDepthMode;                                       /* 88, VR 90 */                                                                            \
-	DepthStencilDepthMode                      depthStencilDepthModePrevious;                               /* 8c, VR 94 - also some kind of mode */                                                   \
-	uint32_t                                   depthStencilStencilMode;                                     /* 90, VR 98 */                                                                            \
-	uint32_t                                   stencilRef;                                                  /* 94, VR 9c */                                                                            \
-	uint32_t                                   rasterStateFillMode;                                         /* 98, VR a0 */                                                                            \
-	uint32_t                                   rasterStateCullMode;                                         /* 9c, VR a4 */                                                                            \
-	uint32_t                                   rasterStateDepthBiasMode;                                    /* a0, VR a8 */                                                                            \
-	uint32_t                                   rasterStateScissorMode;                                      /* a4, VR ac */                                                                            \
-	uint32_t                                   alphaBlendMode;                                              /* a8, VR b0 */                                                                            \
-	uint32_t                                   alphaBlendAlphaToCoverage;                                   /* ac, VR b4 */                                                                            \
-	uint32_t                                   alphaBlendWriteMode;                                         /* b0, VR b8 */                                                                            \
-	bool                                       alphaTestEnabled;                                            /* b4, VR BC */                                                                            \
-	float                                      alphaTestRef;                                                /* b8, VR C0 */                                                                            \
-	REX::EnumSet<TextureAddressMode, uint32_t> PSTextureAddressMode[16];                                    /* bc, VR c4 */                                                                            \
-	REX::EnumSet<TextureFilterMode, uint32_t>  PSTextureFilterMode[16];                                     /* fc, VR 104 */                                                                           \
-	ID3D11ShaderResourceView*                  PSTexture[16];                                               /* 140, VR 148 */                                                                          \
-	REX::EnumSet<TextureAddressMode, uint32_t> CSTextureAddressMode[16];                                    /* 1c0, VR 1c8 */                                                                          \
-	REX::EnumSet<TextureFilterMode, uint32_t>  CSTextureFilterMode[16];                                     /* 200, VR 208 */                                                                          \
-	ID3D11ShaderResourceView*                  CSTexture[16];                                               /* 240, VR 248 */                                                                          \
-	uint32_t                                   CSTextureMinLodMode[16];                                     /* 2c0, VR 2C8 */                                                                          \
-	ID3D11UnorderedAccessView*                 CSUAV[8];                                                    /* 300, VR 308 */                                                                          \
-	ID3D11UnorderedAccessView*                 OMUAV[8];                                                    /* VR 348 only - Output Merger UAVs; accessed as CSUAV[8..15] in SetRenderTargets */       \
-	uint64_t                                   vertexDesc;                                                  /* 340, VR 388 only? */                                                                    \
-	VertexShader*                              currentVertexShader;                                         /* 348, VR 390 */                                                                          \
-	PixelShader*                               currentPixelShader;                                          /* 350, VR 398 */                                                                          \
-	D3D11_PRIMITIVE_TOPOLOGY                   topology;                                                    /* 358, VR 3A0 */                                                                          \
-	EYE_POSITION<NiPoint3, 2>                  posAdjust;                                                   /* 35c, VR 3A4 */                                                                          \
-	EYE_POSITION<NiPoint3, 2>                  previousPosAdjust;                                           /* 368, VR 3BC */                                                                          \
-	uint8_t                                    unk3d4[0x3e0 - 0x3d4];                                       /* VR 3d4 - pad between previousPosAdjust and cameraData (also exists in flat at 0x374) */ \
-	EYE_POSITION<ViewData, 2>                  cameraData;                                                  /* 380, VR 3E0 - size of each is 250 */                                                    \
-	float                                      drawStereo;                                                  /* VR 880 only - stereo rendering mode */                                                  \
-	float                                      viewNear;                                                    /* VR 884 only */                                                                          \
-	float                                      viewFar;                                                     /* VR 888 only */                                                                          \
-	uint32_t                                   alphaBlendModeExtra;                                         /* 5d0, VR 88c */                                                                          \
-	ID3D11Buffer*                              VSConstantBuffers[12];                                       /* VR 890 only */                                                                          \
-	ID3D11Buffer*                              PSConstantBuffers[12];                                       /* VR 8F0 only */
+#define VR_RUNTIME_DATA_CONTENT                                                                                                                                                                                  \
+	REX::EnumSet<ShaderFlags, uint32_t>        stateUpdateFlags;                                                      /* 00 Flags +0x0  0xFFFFFFFF; global state updates */                                      \
+	uint32_t                                   PSResourceModifiedBits;                                                /* 04 Flags +0x4  0xFFFF */                                                                \
+	uint32_t                                   PSSamplerModifiedBits;                                                 /* 08 Flags +0x8  0xFFFF */                                                                \
+	uint32_t                                   CSResourceModifiedBits;                                                /* 0c Flags +0xC  0xFFFF */                                                                \
+	uint32_t                                   CSSamplerModifiedBits;                                                 /* 10 Flags +0x10 0xFFFF */                                                                \
+	uint32_t                                   CSUAVModifiedBits;                                                     /* 14 Flags +0x14 0xFF */                                                                  \
+	uint32_t                                   OMUAVModifiedBits;                                                     /* 18 Flags +0x18 0xFF VR Only  */                                                         \
+	uint32_t                                   SRVModifiedBits;                                                       /* 1c Flags +0x1C 0xFF VR Only  */                                                         \
+	RENDER_TARGET                              renderTargets[REX::W32::D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT];       /* 18, VR 20 */                                                                            \
+	uint32_t                                   depthStencil;                                                          /* 38, VR 40 - Index */                                                                    \
+	uint32_t                                   depthStencilSlice;                                                     /* 3c, VR 44 Index */                                                                      \
+	uint32_t                                   cubeMapRenderTarget;                                                   /* 40, VR 48 = Index */                                                                    \
+	uint32_t                                   cubeMapRenderTargetView;                                               /* 44, VR 4c Index */                                                                      \
+	SetRenderTargetMode                        setRenderTargetMode[REX::W32::D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT]; /* 48, VR 50 */                                                                            \
+	SetRenderTargetMode                        setDepthStencilMode;                                                   /* 68, VR 70 */                                                                            \
+	SetRenderTargetMode                        setCubeMapRenderTargetMode;                                            /* 6c, VR 74 */                                                                            \
+	REX::W32::D3D11_VIEWPORT                   viewPort;                                                              /* 70, VR 78 */                                                                            \
+	DepthStencilDepthMode                      depthStencilDepthMode;                                                 /* 88, VR 90 */                                                                            \
+	DepthStencilDepthMode                      depthStencilDepthModePrevious;                                         /* 8c, VR 94 - also some kind of mode */                                                   \
+	uint32_t                                   depthStencilStencilMode;                                               /* 90, VR 98 */                                                                            \
+	uint32_t                                   stencilRef;                                                            /* 94, VR 9c */                                                                            \
+	uint32_t                                   rasterStateFillMode;                                                   /* 98, VR a0 */                                                                            \
+	uint32_t                                   rasterStateCullMode;                                                   /* 9c, VR a4 */                                                                            \
+	uint32_t                                   rasterStateDepthBiasMode;                                              /* a0, VR a8 */                                                                            \
+	uint32_t                                   rasterStateScissorMode;                                                /* a4, VR ac */                                                                            \
+	uint32_t                                   alphaBlendMode;                                                        /* a8, VR b0 */                                                                            \
+	uint32_t                                   alphaBlendAlphaToCoverage;                                             /* ac, VR b4 */                                                                            \
+	uint32_t                                   alphaBlendWriteMode;                                                   /* b0, VR b8 */                                                                            \
+	bool                                       alphaTestEnabled;                                                      /* b4, VR BC */                                                                            \
+	float                                      alphaTestRef;                                                          /* b8, VR C0 */                                                                            \
+	REX::EnumSet<TextureAddressMode, uint32_t> PSTextureAddressMode[16];                                              /* bc, VR c4 */                                                                            \
+	REX::EnumSet<TextureFilterMode, uint32_t>  PSTextureFilterMode[16];                                               /* fc, VR 104 */                                                                           \
+	REX::W32::ID3D11ShaderResourceView*        PSTexture[16];                                                         /* 140, VR 148 */                                                                          \
+	REX::EnumSet<TextureAddressMode, uint32_t> CSTextureAddressMode[16];                                              /* 1c0, VR 1c8 */                                                                          \
+	REX::EnumSet<TextureFilterMode, uint32_t>  CSTextureFilterMode[16];                                               /* 200, VR 208 */                                                                          \
+	REX::W32::ID3D11ShaderResourceView*        CSTexture[16];                                                         /* 240, VR 248 */                                                                          \
+	uint32_t                                   CSTextureMinLodMode[16];                                               /* 2c0, VR 2C8 */                                                                          \
+	REX::W32::ID3D11UnorderedAccessView*       CSUAV[8];                                                              /* 300, VR 308 */                                                                          \
+	REX::W32::ID3D11UnorderedAccessView*       OMUAV[8];                                                              /* VR 348 only - Output Merger UAVs; accessed as CSUAV[8..15] in SetRenderTargets */       \
+	uint64_t                                   vertexDesc;                                                            /* 340, VR 388 only? */                                                                    \
+	VertexShader*                              currentVertexShader;                                                   /* 348, VR 390 */                                                                          \
+	PixelShader*                               currentPixelShader;                                                    /* 350, VR 398 */                                                                          \
+	REX::W32::D3D11_PRIMITIVE_TOPOLOGY         topology;                                                              /* 358, VR 3A0 */                                                                          \
+	EYE_POSITION<NiPoint3, 2>                  posAdjust;                                                             /* 35c, VR 3A4 */                                                                          \
+	EYE_POSITION<NiPoint3, 2>                  previousPosAdjust;                                                     /* 368, VR 3BC */                                                                          \
+	uint8_t                                    unk3d4[0x3e0 - 0x3d4];                                                 /* VR 3d4 - pad between previousPosAdjust and cameraData (also exists in flat at 0x374) */ \
+	EYE_POSITION<ViewData, 2>                  cameraData;                                                            /* 380, VR 3E0 - size of each is 250 */                                                    \
+	float                                      drawStereo;                                                            /* VR 880 only - stereo rendering mode */                                                  \
+	float                                      viewNear;                                                              /* VR 884 only */                                                                          \
+	float                                      viewFar;                                                               /* VR 888 only */                                                                          \
+	uint32_t                                   alphaBlendModeExtra;                                                   /* 5d0, VR 88c */                                                                          \
+	REX::W32::ID3D11Buffer*                    VSConstantBuffers[12];                                                 /* VR 890 only */                                                                          \
+	REX::W32::ID3D11Buffer*                    PSConstantBuffers[12];                                                 /* VR 8F0 only */
                 VR_RUNTIME_DATA_CONTENT;
 			};
 
@@ -270,7 +270,7 @@ namespace RE
 			{
 				GET_CROSSVR_RUNTIME_MEMBER(PSTexture)
 				GET_CROSSVR_RUNTIME_MEMBER(PSResourceModifiedBits)
-				ID3D11ShaderResourceView* resourceView = newTexture ? newTexture->resourceView : nullptr;
+				REX::W32::ID3D11ShaderResourceView* resourceView = newTexture ? newTexture->resourceView : nullptr;
 				if (PSTexture[textureIndex] != resourceView) {
 					PSTexture[textureIndex] = resourceView;
 					PSResourceModifiedBits |= (1 << textureIndex);
@@ -281,7 +281,7 @@ namespace RE
 			{
 				GET_CROSSVR_RUNTIME_MEMBER(PSTexture)
 				GET_CROSSVR_RUNTIME_MEMBER(PSResourceModifiedBits)
-				ID3D11ShaderResourceView* resourceView = newTexture.SRV;
+				REX::W32::ID3D11ShaderResourceView* resourceView = newTexture.SRV;
 				if (PSTexture[textureIndex] != resourceView) {
 					PSTexture[textureIndex] = resourceView;
 					PSResourceModifiedBits |= (1 << textureIndex);

--- a/src/RE/R/Renderer.cpp
+++ b/src/RE/R/Renderer.cpp
@@ -217,7 +217,7 @@ namespace RE
 			static const bool isVr = REL::Module::IsVR();
 			if (isVr) {
 				auto&      vrData = shadowState->GetVRRuntimeData();
-				auto*      buffer = reinterpret_cast<ID3D11Buffer*>(group.buffer);
+				auto*      buffer = group.buffer;
 				const auto bufferIndex = static_cast<UINT>(level);
 				if (vrData.VSConstantBuffers[bufferIndex] != buffer) {
 					deviceContext->VSSetConstantBuffers(bufferIndex, 1, &group.buffer);
@@ -238,7 +238,7 @@ namespace RE
 			static const bool isVr = REL::Module::IsVR();
 			if (isVr) {
 				auto&      vrData = shadowState->GetVRRuntimeData();
-				auto*      buffer = reinterpret_cast<ID3D11Buffer*>(group.buffer);
+				auto*      buffer = group.buffer;
 				const auto bufferIndex = static_cast<UINT>(level);
 				if (vrData.PSConstantBuffers[bufferIndex] != buffer) {
 					deviceContext->PSSetConstantBuffers(bufferIndex, 1, &group.buffer);


### PR DESCRIPTION
## Summary
- Forward-declared bare `ID3D11*` types (`ID3D11Texture2D`, `ID3D11ShaderResourceView`, `ID3D11Buffer`, etc.) in `NiTexture.h`, `NiSourceTexture.h`, `NiSkinPartition.h`, `RenderTargetData.h`, and `RendererShadowState.h` forced consumers of those RE headers to independently pull in `windows.h`/`d3d11.h` to get a matching declaration.
- Routes all of them through `REX::W32::D3D11.h`, matching the rest of the codebase's convention of never exposing raw Win32/D3D types outside `REX::W32`.
- `Renderer.cpp`: `group.buffer` is already `REX::W32::ID3D11Buffer*` (used unqualified elsewhere in the same file); dropped a now-redundant `reinterpret_cast<ID3D11Buffer*>`.

## Test plan
- [x] `release-msvc-vcpkg-se` builds clean (incl. `CommonLibSSETests`)
- [x] `release-msvc-vcpkg-vr` builds clean
- [x] Swept the repo for any remaining unqualified `ID3D11*`/`IDXGI*`/`D3D11_*` usage or raw `windows.h`/`d3d11.h` includes outside `REX::W32` itself — none found

Co-authored-by: expired6978 <1918443+expired6978@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized Direct3D 11 resource and rendering types across graphics interfaces.
  * Improved consistency and compatibility for texture, buffer, render target, and renderer state integrations.
  * Preserved existing data layouts, field offsets, initialization, and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->