### PR TITLE
feat(racesexmenu): type headPart/slider fields

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -1659,6 +1659,7 @@ set(SOURCES
 	include/RE/Q/QueuedFile.h
 	include/RE/Q/QuickSaveLoadHandler.h
 	include/RE/R/REFREventCallbacks.h
+	include/RE/R/RaceMenuSlider.h
 	include/RE/R/RaceSexCamera.h
 	include/RE/R/RaceSexMenu.h
 	include/RE/R/RaceSexMenuEvent.h

--- a/include/RE/R/RaceMenuSlider.h
+++ b/include/RE/R/RaceMenuSlider.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "RE/B/BSTArray.h"
+
+namespace RE
+{
+	class TESRace;
+
+	// RaceSexMenu::RUNTIME_DATA::sliderData element. No RTTI (POD); verified
+	// against SkyrimSE.exe: sizeof 0x138, index at +0x124, +0x130 is float
+	// (not uint32) with a ~FLT_MAX sentinel for "unset".
+	struct RaceMenuSlider
+	{
+		enum
+		{
+			kTypeHeadPart = 0,
+			kTypeUnk1,
+			kTypeDoubleMorph,
+			kTypePreset,
+			kTypeTintingMask,
+			kTypeHairColorPreset,
+			kTypeUnk6,
+			kTypeUnused7,
+			kTypeUnk8,
+			kTypeUnk9,
+			kTypeUnk10
+		};
+
+		float         min;            // 000
+		float         max;            // 004
+		float         value;          // 008
+		float         interval;       // 00C
+		std::uint32_t filterFlag;     // 010
+		std::uint32_t type;           // 014
+		const char*   name;           // 018
+		char          callback[260];  // 020
+		std::uint32_t index;          // 124 - index into the associated head-part list
+		std::uint32_t id;             // 128
+		std::uint32_t unk12C;         // 12C
+		float         currentValue;   // 130 - selected value; ~FLT_MAX sentinel when unset
+		std::uint8_t  unk134;         // 134
+		std::uint8_t  pad135[3];      // 135
+	};
+	static_assert(sizeof(RaceMenuSlider) == 0x138);
+
+	using RaceMenuSliderArray = BSTArray<RaceMenuSlider>;
+
+	// One race+sex slider set. Stride 0x28 verified against SkyrimSE.exe.
+	struct RaceComponent
+	{
+		TESRace*            race;     // 00
+		RaceMenuSliderArray sliders;  // 08
+		std::uint32_t       unk20;    // 20
+		std::uint32_t       pad24;    // 24
+	};
+	static_assert(sizeof(RaceComponent) == 0x28);
+}

--- a/include/RE/R/RaceSexMenu.h
+++ b/include/RE/R/RaceSexMenu.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "RE/B/BGSHeadPart.h"
 #include "RE/B/BSTArray.h"
 #include "RE/I/IMenu.h"
 #include "RE/M/MenuEventHandler.h"
+#include "RE/R/RaceMenuSlider.h"
 #include "RE/R/RaceSexCamera.h"
 #include "RE/S/Sexes.h"
 #include "REL/RuntimeDataAccessors.h"
@@ -26,22 +28,22 @@ namespace RE
 
 		struct RUNTIME_DATA
 		{
-#define RUNTIME_DATA_CONTENT                              \
-	BSTArray<void*>                  unk040[7]; /* 000 */ \
-	RaceSexCamera                    camera;    /* 0A8 */ \
-	BSTArray<void*>                  unk140[2]; /* 100 */ \
-	BSTArray<void*>                  unk170;    /* 130 */ \
-	std::uint64_t                    unk188;    /* 148 */ \
-	std::uint32_t                    unk190;    /* 150 */ \
-	std::uint32_t                    unk194;    /* 154 */ \
-	REX::EnumSet<SEX, std::uint32_t> sex;       /* 158 */ \
-	std::uint16_t                    unk19C;    /* 15C */ \
-	std::uint8_t                     unk19E;    /* 15E */ \
-	std::uint8_t                     pad19F;    /* 15F */ \
-	std::uint8_t                     unk1A0;    /* 160 */ \
-	std::uint8_t                     unk1A1;    /* 161 */ \
-	std::uint16_t                    unk1A2;    /* 162 */ \
-	std::uint32_t                    unk1A4;    /* 164 */
+#define RUNTIME_DATA_CONTENT                                  \
+	BSTArray<BGSHeadPart*>           headParts[7];  /* 000 */ \
+	RaceSexCamera                    camera;        /* 0A8 */ \
+	BSTArray<RaceComponent>          sliderData[2]; /* 100 */ \
+	BSTArray<void*>                  unk170;        /* 130 */ \
+	std::uint64_t                    unk188;        /* 148 */ \
+	std::uint32_t                    unk190;        /* 150 */ \
+	std::uint32_t                    unk194;        /* 154 */ \
+	REX::EnumSet<SEX, std::uint32_t> sex;           /* 158 */ \
+	std::uint16_t                    unk19C;        /* 15C */ \
+	std::uint8_t                     unk19E;        /* 15E */ \
+	std::uint8_t                     pad19F;        /* 15F */ \
+	std::uint8_t                     unk1A0;        /* 160 */ \
+	std::uint8_t                     unk1A1;        /* 161 */ \
+	std::uint16_t                    unk1A2;        /* 162 */ \
+	std::uint32_t                    unk1A4;        /* 164 */
             RUNTIME_DATA_CONTENT
 		};
 		static_assert(sizeof(RUNTIME_DATA) == 0x168);

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -1659,6 +1659,7 @@
 #include "RE/Q/QueuedFile.h"
 #include "RE/Q/QuickSaveLoadHandler.h"
 #include "RE/R/REFREventCallbacks.h"
+#include "RE/R/RaceMenuSlider.h"
 #include "RE/R/RaceSexCamera.h"
 #include "RE/R/RaceSexMenu.h"
 #include "RE/R/RaceSexMenuEvent.h"


### PR DESCRIPTION
## Summary
- `RaceSexMenu::RUNTIME_DATA` previously modeled its head-part list and per-race slider set as untyped `BSTArray<void*>` arrays. Retypes them to `BSTArray<BGSHeadPart*> headParts[7]` and `BSTArray<RaceComponent> sliderData[2]`.
- Adds `RE::RaceMenuSlider` and `RE::RaceComponent` (new `include/RE/R/RaceMenuSlider.h`). No RTTI on these (POD, no vtable), so unlike `RaceSexMenu` itself the type names are a modding-community convention, not compiler-verified symbols.
- Verified against `SkyrimSE.exe`: `sizeof(RaceMenuSlider) == 0x138` (the IMUL stride used throughout `RaceSexMenu::sub_1408B44xx`-`sub_1408B51xx`), `index` field at `+0x124`, and the `+0x130` field confirmed to be a `float` (not the `uint32` commonly assumed) via its exclusive use with float instructions and a `~FLT_MAX` sentinel for "unset".
- `BSTArray<T>` is a fixed-size handle regardless of `T`, so this retype doesn't change `sizeof(RaceSexMenu)` or any `STATIC_ASSERT_SIZE`.

## Test plan
- [x] `release-msvc-vcpkg-se` builds clean (incl. `CommonLibSSETests`, all `STATIC_ASSERT_SIZE`/`RuntimeDataAccessors` tests pass)
- [x] `release-msvc-vcpkg-vr` builds clean

Co-authored-by: expired6978 <1918443+expired6978@users.noreply.github.com>