### PR TITLE
fix(vr): correct render-mode 24 enum name

### DIFF
--- a/include/RE/B/BSShaderAccumulator.h
+++ b/include/RE/B/BSShaderAccumulator.h
@@ -24,11 +24,11 @@ namespace RE
 			kLodLandscapePass = 0x14,
 			kWaterReflectionPass = 0x15,
 			kBloodDecalPass = 0x16,
-			kAlphaTransparencyShadowPass = 0x17,
-			kSunGlintRefractionPass = 0x18,
-			kVolumetricLightingPass = 0x19,
-			kOcclusion = 0x1A,
-			kPrecipitationOcclusionMap = 0x1C
+			kAlphaTransparencyShadowPass = 0x17,  // no-op on SE/AE/VR (verified: bare `return`)
+			kFinishAccumulatingMode24 = 0x18,     // dispatch index only -- SE/AE/VR each run unrelated code here
+			kVolumetricLightingPass = 0x19,       // VR: unrelated (ends first-person view instead); SE/AE only
+			kOcclusion = 0x1A,                    // VR: shared with 0x1B, different handler; SE/AE only
+			kPrecipitationOcclusionMap = 0x1C     // VR has no handler at this slot
 		};
 
 		class SunOcclusionTest

--- a/include/RE/B/BSShaderAccumulator.h
+++ b/include/RE/B/BSShaderAccumulator.h
@@ -25,9 +25,8 @@ namespace RE
 			kWaterReflectionPass = 0x15,
 			kBloodDecalPass = 0x16,
 			kAlphaTransparencyShadowPass = 0x17,  // no-op on SE/AE/VR (verified: bare `return`)
-			// Dispatch slot 0x18: all three runtimes run unrelated code, so it's aliased per-runtime
-			// below rather than under one name (was kSunGlintRefractionPass, unrelated to any of
-			// them and unrelated to the real FinishAccumulatingSunGlint() virtual above).
+			// Slot 0x18 dispatches unrelated code per runtime, so it's aliased below rather than
+			// given one shared name.
 			kSEEndFirstPersonView = 0x18,
 			kAEResetQueuedShadowPassList = 0x18,
 			kVRWorldSpaceUIPass = 0x18,

--- a/include/RE/B/BSShaderAccumulator.h
+++ b/include/RE/B/BSShaderAccumulator.h
@@ -31,9 +31,9 @@ namespace RE
 			kSEEndFirstPersonView = 0x18,
 			kAEResetQueuedShadowPassList = 0x18,
 			kVRWorldSpaceUIPass = 0x18,
-			kVolumetricLightingPass = 0x19,  // SE/AE; shared with kOcclusion's handler
-			kVREndFirstPersonView = 0x19,    // VR: kSEEndFirstPersonView's behavior sits here instead
-			kOcclusion = 0x1A,               // SE/AE; VR shares this slot with 0x1B under a different handler
+			kVolumetricLightingPass = 0x19,    // SE/AE; shared with kOcclusion's handler
+			kVREndFirstPersonView = 0x19,      // VR: kSEEndFirstPersonView's behavior sits here instead
+			kOcclusion = 0x1A,                 // SE/AE; VR shares this slot with 0x1B under a different handler
 			kPrecipitationOcclusionMap = 0x1C  // SE/AE only -- VR has no handler at this slot
 		};
 

--- a/include/RE/B/BSShaderAccumulator.h
+++ b/include/RE/B/BSShaderAccumulator.h
@@ -25,10 +25,16 @@ namespace RE
 			kWaterReflectionPass = 0x15,
 			kBloodDecalPass = 0x16,
 			kAlphaTransparencyShadowPass = 0x17,  // no-op on SE/AE/VR (verified: bare `return`)
-			kFinishAccumulatingMode24 = 0x18,     // dispatch index only -- SE/AE/VR each run unrelated code here
-			kVolumetricLightingPass = 0x19,       // VR: unrelated (ends first-person view instead); SE/AE only
-			kOcclusion = 0x1A,                    // VR: shared with 0x1B, different handler; SE/AE only
-			kPrecipitationOcclusionMap = 0x1C     // VR has no handler at this slot
+			// Dispatch slot 0x18: all three runtimes run unrelated code, so it's aliased per-runtime
+			// below rather than under one name (was kSunGlintRefractionPass, unrelated to any of
+			// them and unrelated to the real FinishAccumulatingSunGlint() virtual above).
+			kSEEndFirstPersonView = 0x18,
+			kAEResetQueuedShadowPassList = 0x18,
+			kVRWorldSpaceUIPass = 0x18,
+			kVolumetricLightingPass = 0x19,  // SE/AE; shared with kOcclusion's handler
+			kVREndFirstPersonView = 0x19,    // VR: kSEEndFirstPersonView's behavior sits here instead
+			kOcclusion = 0x1A,               // SE/AE; VR shares this slot with 0x1B under a different handler
+			kPrecipitationOcclusionMap = 0x1C  // SE/AE only -- VR has no handler at this slot
 		};
 
 		class SunOcclusionTest


### PR DESCRIPTION
## Summary
`kSunGlintRefractionPass = 0x18` matched no runtime's actual behavior and had zero usages anywhere in this repo (open-shaders calls the raw literal `24`, precisely because the name was unusable). It's also unrelated to the real `FinishAccumulatingSunGlint()` virtual on this same class (vtable slot 0x2C) — likely the actual source of the "SunGlint" name, misattributed to the wrong slot.

Traced `BSShaderAccumulator::InitFinishModeTable`'s dispatch-table writes and decompiled each populated handler on SE 1.5.97, AE 1.6.1170, and VR 1.4.15:
- Slot `0x18`: all three runtimes run unrelated code here (SE ends first-person-view compositing, AE frees a queued shadow-pass list, VR renders the world-space UI/HUD batch). Since one name can't accurately describe all three, and C++ allows enumerators to alias the same value, each runtime's behavior gets its own name — `kSEEndFirstPersonView` / `kAEResetQueuedShadowPassList` / `kVRWorldSpaceUIPass` — following this repo's existing `kFlat`/`kAE`/`kVR` tagging convention (see `kFlatVirtualKeyboard`/`kAETotal`/`kVRPlayroomQuest` etc.).
- Slot `0x19` (`kVolumetricLightingPass`): SE/AE share this handler; VR does not — VR instead runs its first-person-view-end handler here (aliased as `kVREndFirstPersonView`).
- Slot `0x1A` (`kOcclusion`): VR shares this slot with 0x1B under a different handler than SE/AE.
- Slot `0x1C` (`kPrecipitationOcclusionMap`): no VR handler at all.

## Test plan
- [x] Header-only change; confirmed the old name had zero usages before renaming.
- [ ] Downstream build verification in open-shaders (uses the raw literal `24`, unaffected by this rename).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated rendering mode definitions to distinguish behavior across supported runtime variants.
  * Added explicit identifiers for first-person view transitions, shadow-pass resets, and world-space UI rendering.
  * Replaced a generic rendering mode label with more descriptive runtime-specific names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->