### PR TITLE
feat(decal): add BGSDecalManager::ApplyDecal binding

### DIFF
--- a/include/RE/B/BGSDecalManager.h
+++ b/include/RE/B/BGSDecalManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "RE/B/BGSDecalGroup.h"
 #include "RE/B/BSTArray.h"
 #include "RE/B/BSTempEffectSimpleDecal.h"
 #include "RE/N/NiSmartPointer.h"
@@ -16,6 +17,15 @@ namespace RE
 		{
 			static REL::Relocation<BGSDecalManager**> singleton{ RELOCATION_ID(514414, 400561) };
 			return *singleton;
+		}
+
+		// The engine call every vanilla decal (blood, scorch) already goes
+		// through -- lets a caller place one without a real hit event.
+		void ApplyDecal(DECAL_CREATION_DATA& a_data, bool a_forceDecal = false, BGSDecalGroup* a_group = nullptr)
+		{
+			using func_t = decltype(&BGSDecalManager::ApplyDecal);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(15029, 15203) };
+			return func(this, a_data, a_forceDecal, a_group);
 		}
 
 		// members


### PR DESCRIPTION
**⚠️ Draft -- do not merge before alandtse/skyrim_vr_address_library#202.** `RELOCATION_ID(15029, 15203)` only resolves on VR once id `15029` is in the *published* address-library database and a new release is regenerated/tagged (`skyrim_vr_address_library` `main` doesn't have it yet -- confirmed live). Merging this first hard-crashes VR at plugin load for anyone consuming this id. Mark ready once #202 is merged and a release cut.

## Summary
- Exposes `BGSDecalManager::ApplyDecal(DECAL_CREATION_DATA&, bool, BGSDecalGroup*)` -- the same engine call every vanilla blood/scorch decal already goes through -- letting a plugin place one deliberately (no live hit event required).
- RE-verified from scratch this session: decompiled and named the real function in all three runtimes via Ghidra (SE `0x1401ad2f0`, AE `0x1401f9830`, VR `0x1401bd040`), then cross-checked with Ghidra Version Tracking -- structurally identical logic and field offsets across all three (same `bDecals`/`bForceAllDecals` gate, same `fDecalLOD0_Display` distance check, same `NiAVObject::FindEligibleAttachNode` call at the end).
- SE address-library id `15029` was independently re-verified (a third-party PR's claimed ids for two *sibling* functions turned out to be wrong/stale when checked against this binary; this one held up). AE id `15203` found via the offsets CSV.
- Companion `skyrim_vr_address_library` PR registering the VR address: alandtse/skyrim_vr_address_library#202

## Test plan
- [x] `clang-format --dry-run --Werror` clean on the changed file
- [x] Builds cleanly as a vendored dependency (CompanionExpeditions's own `xmake build` against this tree, full rebuild, no warnings from the new code)
- [x] `python vr_address_tools.py . generate` (companion PR #202) confirms id 15029 resolves to the correct VR offset in the generated release csv
- [ ] Full `scripts/build-all-presets.cmd` (all 5 presets) -- not yet run this session
- [ ] #202 merged + release regenerated (blocks marking this ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFVUotH6aA9MfnEkfEucUF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public capability for placing decals without requiring a hit event.
  - Supports optional forced placement and decal group selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->