### PR TITLE
fix(variable): pack null handles as typed None

### DIFF
--- a/include/RE/P/PackUnpackImpl.h
+++ b/include/RE/P/PackUnpackImpl.h
@@ -51,6 +51,16 @@ namespace RE
 			while (it != end) {
 				if constexpr (std::is_same_v<U, std::vector<bool>>) {
 					(*array)[i++].Pack(static_cast<bool>(*it));
+				} else if constexpr (is_form_pointer_v<typename U::value_type> ||
+									 is_alias_pointer_v<typename U::value_type> ||
+									 is_active_effect_pointer_v<typename U::value_type>) {
+					// PackHandle's null path drops the element's type (SetNone()); an
+					// untyped None here silently rejects later in-script reassignment.
+					if (*it) {
+						(*array)[i++].Pack(*it);
+					} else {
+						(*array)[i++] = Variable(typeInfo);
+					}
 				} else {
 					(*array)[i++].Pack(*it);
 				}


### PR DESCRIPTION
## Summary
Fixes #333. A `std::vector<T*>` (form/alias/active-effect pointer) with `nullptr` entries, packed into a Papyrus array via `PackValue`, produced array elements that couldn't later be reassigned from script (`keywordArray[i] = someKeyword` silently no-opped).

Traced the exact mechanism:

- `RE::BSScript::Variable::SetNone()` calls `ChangeType(TypeInfo::RawType::kNone)` -- the generic, class-agnostic None type.
- `PackHandle()` (what a form/alias/active-effect pointer's `Variable::Pack()` routes through) calls `a_dst->SetNone()` unconditionally for a null pointer and returns early -- it only attaches the specific class type (`a_dst->SetObject(objectPtr, classPtr->GetRawType())`) on the *non-null* path.
- So a null entry inside an array ends up generically-typed (`kNone`), while a real engine-created array's elements are always typed to the array's declared element class, null or not. That mismatch is what makes the real Papyrus VM refuse the later in-script reassignment -- CommonLib wasn't constructing the array the way the engine itself would.

## Fix
In `PackValue`'s array-packing loop, for the form/alias/active-effect-pointer element case: pack normally when non-null, but construct a properly-typed None (`Variable(typeInfo)`, reusing the exact `TypeInfo` already computed for `vm->CreateArray` -- the same per-element class type `PackHandle`'s success path uses via `classPtr->GetRawType()`) when null, instead of routing through the generic `SetNone()` path.

## Verification
- Confirmed by reading `Variable.cpp`/`PackUnpack.cpp`/`TypeInfo.h` directly rather than assuming -- this is a genuine type-fidelity gap between CommonLib's array construction and how the engine itself types array elements, not a hypothesis.
- `.\scripts\build-all-presets.cmd --clang` and `.\scripts\build-all-presets.cmd` (MSVC) -- all 10 preset/compiler combinations (se/ae/vr/flatrim/all x debug isn't built by this script, release only) succeed.
- The reporter (@Dylbill-Iroh) independently tested the equivalent fix in-game across `RE::Actor*`, `RE::BGSKeyword*`, `RE::BGSBaseAlias*`, and `RE::ActiveEffect*` and confirmed it resolves the reassignment failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAtA2W2RXLuKGJiZaacvjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved serialization of arrays containing null references.
  - Null entries now retain their expected type information when packed, improving consistency when the data is later unpacked or interpreted.
  - Existing handling of non-null references remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->