### PR TITLE
fix(runtime): fix BSMultiStreamInstanceTriShape vtable

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -2163,6 +2163,7 @@ set(SOURCES
 	src/RE/B/BSModelDB.cpp
 	src/RE/B/BSMouseDevice.cpp
 	src/RE/B/BSMultiBoundNode.cpp
+	src/RE/B/BSMultiStreamInstanceTriShape.cpp
 	src/RE/B/BSOcclusionPlane.cpp
 	src/RE/B/BSOpenVR.cpp
 	src/RE/B/BSPCGamepadDeviceDelegate.cpp

--- a/include/RE/B/BSMultiBoundShape.h
+++ b/include/RE/B/BSMultiBoundShape.h
@@ -4,6 +4,9 @@
 
 namespace RE
 {
+	class BSMultiBound;
+	class NiFrustumPlanes;
+
 	class BSMultiBoundShape : public NiObject
 	{
 	public:

--- a/include/RE/B/BSMultiStreamInstanceTriShape.h
+++ b/include/RE/B/BSMultiStreamInstanceTriShape.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "RE/B/BSInstanceTriShape.h"
+#include "RE/B/BSMultiBoundAABB.h"
 #include "REL/RuntimeDataAccessors.h"
 
 namespace RE
@@ -73,19 +74,17 @@ namespace RE
 		// override (BSInstanceTriShape)
 		const NiRTTI* GetRTTI() const override;                           // 02
 		NiObject*     CreateClone(NiCloningProcess& a_cloning) override;  // 17
-#if defined(EXCLUSIVE_SKYRIM_FLAT)
-		// The following are virtual functions past the point where VR compatibility breaks.
-		void OnVisible(NiCullingProcess& a_process, std::int32_t a_alphaGroupIndex) override;  // 34
+		// VR inserts a virtual before these slots; keep the SE/AE and VR indices paired.
+		SKYRIM_REL_VR_VIRTUAL void OnVisible(NiCullingProcess& a_process, std::int32_t a_alphaGroupIndex);  // 34/35
 
 		// overrides for BSTriShape
-		std::uint32_t GetVisibleGroupsTriangleCount() override;                                                                            // 37
-		void          BeginAddingInstances(std::uint32_t a_numFloatsPerInstance) override;                                                 // 38
-		void          AddInstances(std::uint32_t a_numFloatsPerInstance, std::uint16_t& a_instanceData) override;                          // 39
-		void          DoneAddingInstances(BSTArray<std::uint32_t>& a_instances) override;                                                  // 3A
-		bool          GetIsAddingInstances() override;                                                                                     // 3B
-		std::uint32_t AddGroup(std::uint32_t a_numInstances, std::uint16_t& a_instanceData, std::uint32_t a_arg3, float a_arg4) override;  // 3C
-		void          RemoveGroup(std::uint32_t a_numInstance) override;                                                                   // 3D
-#endif
+		SKYRIM_REL_VR_VIRTUAL std::uint32_t GetVisibleGroupsTriangleCount();                                                                            // 37/38
+		SKYRIM_REL_VR_VIRTUAL void          BeginAddingInstances(std::uint32_t a_numFloatsPerInstance);                                                 // 38/39
+		SKYRIM_REL_VR_VIRTUAL void          AddInstances(std::uint32_t a_numFloatsPerInstance, std::uint16_t& a_instanceData);                          // 39/3A
+		SKYRIM_REL_VR_VIRTUAL void          DoneAddingInstances(BSTArray<std::uint32_t>& a_instances);                                                  // 3A/3B
+		SKYRIM_REL_VR_VIRTUAL bool          GetIsAddingInstances();                                                                                     // 3B/3C
+		SKYRIM_REL_VR_VIRTUAL std::uint32_t AddGroup(std::uint32_t a_numInstances, std::uint16_t& a_instanceData, std::uint32_t a_arg3, float a_arg4);  // 3C/3D
+		SKYRIM_REL_VR_VIRTUAL void          RemoveGroup(std::uint32_t a_numInstance);                                                                   // 3D/3E
 
 		RUNTIME_DATA_ACCESSOR_EX(MULTISTREAM_TRISHAPE_RUNTIME_DATA, GetMultiStreamTrishapeRuntimeData, 0x160, 0x1A0);
 		// members

--- a/src/RE/B/BSMultiStreamInstanceTriShape.cpp
+++ b/src/RE/B/BSMultiStreamInstanceTriShape.cpp
@@ -1,0 +1,46 @@
+#include "RE/B/BSMultiStreamInstanceTriShape.h"
+
+namespace RE
+{
+#ifdef SKYRIM_CROSS_VR
+	void BSMultiStreamInstanceTriShape::OnVisible(NiCullingProcess& a_process, std::int32_t a_alphaGroupIndex)
+	{
+		REL::RelocateVirtual<decltype(&BSMultiStreamInstanceTriShape::OnVisible)>(0x34, 0x35, this, a_process, a_alphaGroupIndex);
+	}
+
+	std::uint32_t BSMultiStreamInstanceTriShape::GetVisibleGroupsTriangleCount()
+	{
+		return REL::RelocateVirtual<decltype(&BSMultiStreamInstanceTriShape::GetVisibleGroupsTriangleCount)>(0x37, 0x38, this);
+	}
+
+	void BSMultiStreamInstanceTriShape::BeginAddingInstances(std::uint32_t a_numFloatsPerInstance)
+	{
+		REL::RelocateVirtual<decltype(&BSMultiStreamInstanceTriShape::BeginAddingInstances)>(0x38, 0x39, this, a_numFloatsPerInstance);
+	}
+
+	void BSMultiStreamInstanceTriShape::AddInstances(std::uint32_t a_numFloatsPerInstance, std::uint16_t& a_instanceData)
+	{
+		REL::RelocateVirtual<decltype(&BSMultiStreamInstanceTriShape::AddInstances)>(0x39, 0x3A, this, a_numFloatsPerInstance, a_instanceData);
+	}
+
+	void BSMultiStreamInstanceTriShape::DoneAddingInstances(BSTArray<std::uint32_t>& a_instances)
+	{
+		REL::RelocateVirtual<decltype(&BSMultiStreamInstanceTriShape::DoneAddingInstances)>(0x3A, 0x3B, this, a_instances);
+	}
+
+	bool BSMultiStreamInstanceTriShape::GetIsAddingInstances()
+	{
+		return REL::RelocateVirtual<decltype(&BSMultiStreamInstanceTriShape::GetIsAddingInstances)>(0x3B, 0x3C, this);
+	}
+
+	std::uint32_t BSMultiStreamInstanceTriShape::AddGroup(std::uint32_t a_numInstances, std::uint16_t& a_instanceData, std::uint32_t a_arg3, float a_arg4)
+	{
+		return REL::RelocateVirtual<decltype(&BSMultiStreamInstanceTriShape::AddGroup)>(0x3C, 0x3D, this, a_numInstances, a_instanceData, a_arg3, a_arg4);
+	}
+
+	void BSMultiStreamInstanceTriShape::RemoveGroup(std::uint32_t a_numInstance)
+	{
+		REL::RelocateVirtual<decltype(&BSMultiStreamInstanceTriShape::RemoveGroup)>(0x3D, 0x3E, this, a_numInstance);
+	}
+#endif
+}


### PR DESCRIPTION
## Summary
Fixes `BSMultiStreamInstanceTriShape`'s cross-runtime (SKYRIM_CROSS_VR) support for 8 methods that were previously `EXCLUSIVE_SKYRIM_FLAT`-only: `OnVisible`, `GetVisibleGroupsTriangleCount`, `BeginAddingInstances`, `AddInstances`, `DoneAddingInstances`, `GetIsAddingInstances`, `AddGroup`, `RemoveGroup`.

## Root cause
VR's `NiAVObject::ApplyLocalTransformToWorld` is a real VR-only virtual (already declared here under `EXCLUSIVE_SKYRIM_VR`) slotted in right before `PerformOp`. That inserts one extra vtable entry ahead of everything from `PerformOp` onward, so **every subsequent slot in the whole `NiAVObject`-derived hierarchy is +1 on VR relative to SE/AE** — including all 8 methods this class declares past that point. Confirmed by direct vtable reads against both `SkyrimSE.exe` and `SkyrimVR.exe` in Ghidra (not derived/guessed):

| Method | SE/AE slot | VR slot |
|---|---|---|
| `OnVisible` | 0x34 | 0x35 |
| `GetVisibleGroupsTriangleCount` | 0x37 | 0x38 |
| `BeginAddingInstances` | 0x38 | 0x39 |
| `AddInstances` | 0x39 | 0x3A |
| `DoneAddingInstances` | 0x3A | 0x3B |
| `GetIsAddingInstances` | 0x3B | 0x3C |
| `AddGroup` | 0x3C | 0x3D |
| `RemoveGroup` | 0x3D | 0x3E |

A `SKYRIM_CROSS_VR` (universal) build can't express this runtime-varying layout through plain C++ `override`, which is presumably why these were previously excluded from cross builds entirely rather than fixed.

## Fix
Follows the exact pattern `NiAVObject` already uses for its own variant-slot methods (`PerformOp`, `AttachProperty`, `SetMaterialNeedsUpdate`, etc. — see `NiAVObject.h`/`.cpp`): declare with `SKYRIM_REL_VR_VIRTUAL` instead of `override`, and dispatch through `REL::RelocateVirtual<Fn>(seSlot, vrSlot, this, args...)` with the verified per-runtime slot pair, so a universal build resolves the correct slot at runtime instead of needing every caller to branch on `REL::Module::IsVR()` itself.

Also fixes two pre-existing missing-include gaps CI surfaced once a standalone `.cpp` finally included these headers in isolation (previously always riding along after some other header happened to supply the same types first):
- `BSMultiBoundShape.h` uses `BSMultiBound`/`NiFrustumPlanes` by reference without forward-declaring them.
- `BSMultiStreamInstanceTriShape.h` derives `InstanceGroup` from `BSMultiBoundAABB` without including its definition.

## How this was found
Root-caused while fixing a hard VR crash in `alandtse/open-shaders`' Grass Optimizations feature. It hooked `OnVisible`/`DoneAddingInstances` directly via `VTABLE_BSMultiStreamInstanceTriShape[0]` using their SE/AE indices, which silently landed on `PostAttachUpdate`/`AddInstances` instead on VR. `AddInstances`' real signature is `(uint32_t count, uint16_t* data)`, not `DoneAddingInstances`' single `BSTArray&` — so the mismatched call left a garbage pointer in a register that crashed the moment the real `AddInstances` implementation dereferenced it on the first grass cell load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved runtime compatibility for multi-stream instance shapes across supported Skyrim editions, including VR.
  - Corrected virtual method dispatch to account for platform-specific layout differences.
  - Improved handling of instance visibility, grouping, and streaming operations across supported editions.

- **Build**
  - Included the multi-stream instance shape implementation in the build.
  - Added required type declarations for improved compilation compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->