### PR TITLE
refactor(REL): add VersionShift for AE1799 shifts

### DIFF
--- a/include/RE/B/BSSaveDataSystemUtility.h
+++ b/include/RE/B/BSSaveDataSystemUtility.h
@@ -134,22 +134,23 @@ namespace RE
 		virtual void Unk_10(void);  // 10 - { return 0; }
 		virtual void Unk_11(void);  // 11 - { return; }
 #else
-		void Unk_05(void)
+		static constexpr std::size_t kAE1799AddedVFuncCount = 6;  // matches Unk_05AE..Unk_0AAE above
+		void                         Unk_05(void)
 		{
-			REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x05, 6), REL::AE1799Shift(0x05, 6), this);
+			REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x05, kAE1799AddedVFuncCount), REL::AE1799Shift(0x05, kAE1799AddedVFuncCount), this);
 		}
-		void Unk_06(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x06, 6), REL::AE1799Shift(0x06, 6), this); }
-		void Unk_07(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x07, 6), REL::AE1799Shift(0x07, 6), this); }
-		void Unk_08(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x08, 6), REL::AE1799Shift(0x08, 6), this); }
-		void Unk_09(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x09, 6), REL::AE1799Shift(0x09, 6), this); }
-		void Unk_0A(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0A, 6), REL::AE1799Shift(0x0A, 6), this); }
-		void Unk_0B(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0B, 6), REL::AE1799Shift(0x0B, 6), this); }
-		void Unk_0C(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0C, 6), REL::AE1799Shift(0x0C, 6), this); }
-		void Unk_0D(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0D, 6), REL::AE1799Shift(0x0D, 6), this); }
-		void Unk_0E(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0E, 6), REL::AE1799Shift(0x0E, 6), this); }
-		void Unk_0F(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0F, 6), REL::AE1799Shift(0x0F, 6), this); }
-		void Unk_10(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x10, 6), REL::AE1799Shift(0x10, 6), this); }
-		void Unk_11(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x11, 6), REL::AE1799Shift(0x11, 6), this); }
+		void Unk_06(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x06, kAE1799AddedVFuncCount), REL::AE1799Shift(0x06, kAE1799AddedVFuncCount), this); }
+		void Unk_07(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x07, kAE1799AddedVFuncCount), REL::AE1799Shift(0x07, kAE1799AddedVFuncCount), this); }
+		void Unk_08(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x08, kAE1799AddedVFuncCount), REL::AE1799Shift(0x08, kAE1799AddedVFuncCount), this); }
+		void Unk_09(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x09, kAE1799AddedVFuncCount), REL::AE1799Shift(0x09, kAE1799AddedVFuncCount), this); }
+		void Unk_0A(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0A, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0A, kAE1799AddedVFuncCount), this); }
+		void Unk_0B(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0B, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0B, kAE1799AddedVFuncCount), this); }
+		void Unk_0C(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0C, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0C, kAE1799AddedVFuncCount), this); }
+		void Unk_0D(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0D, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0D, kAE1799AddedVFuncCount), this); }
+		void Unk_0E(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0E, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0E, kAE1799AddedVFuncCount), this); }
+		void Unk_0F(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0F, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0F, kAE1799AddedVFuncCount), this); }
+		void Unk_10(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x10, kAE1799AddedVFuncCount), REL::AE1799Shift(0x10, kAE1799AddedVFuncCount), this); }
+		void Unk_11(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x11, kAE1799AddedVFuncCount), REL::AE1799Shift(0x11, kAE1799AddedVFuncCount), this); }
 #endif
 
 		// members

--- a/include/RE/B/BSSaveDataSystemUtility.h
+++ b/include/RE/B/BSSaveDataSystemUtility.h
@@ -4,6 +4,7 @@
 #include "RE/B/BSString.h"
 #include "RE/B/BSTEvent.h"
 #include "REL/Relocation.h"
+#include "REL/RuntimeDataAccessors.h"
 #include "SKSE/Version.h"
 
 namespace RE
@@ -71,8 +72,6 @@ namespace RE
 		virtual void    Unk_04(void);                                                                                    // 04 - { return; }
 
 #ifdef ENABLE_SKYRIM_AE
-#	define AE1799_SLOT_SHIFT(idx) (REL::Module::IsAtLeast(SKSE::RUNTIME_SSE_1_7_99) ? (idx) + 6 : (idx))
-
 		bool Unk_05AE(void)
 		{
 			if (!REL::Module::IsAtLeast(SKSE::RUNTIME_SSE_1_7_99)) {
@@ -118,8 +117,6 @@ namespace RE
 			REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(0x0A, 0x0A, this);
 			return true;
 		}
-#else
-#	define AE1799_SLOT_SHIFT(idx) (idx)
 #endif
 
 #ifndef ENABLE_SKYRIM_AE
@@ -139,22 +136,21 @@ namespace RE
 #else
 		void Unk_05(void)
 		{
-			REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(AE1799_SLOT_SHIFT(0x05), AE1799_SLOT_SHIFT(0x05), this);
+			REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x05, 6), REL::AE1799Shift(0x05, 6), this);
 		}
-		void Unk_06(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(AE1799_SLOT_SHIFT(0x06), AE1799_SLOT_SHIFT(0x06), this); }
-		void Unk_07(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(AE1799_SLOT_SHIFT(0x07), AE1799_SLOT_SHIFT(0x07), this); }
-		void Unk_08(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(AE1799_SLOT_SHIFT(0x08), AE1799_SLOT_SHIFT(0x08), this); }
-		void Unk_09(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(AE1799_SLOT_SHIFT(0x09), AE1799_SLOT_SHIFT(0x09), this); }
-		void Unk_0A(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(AE1799_SLOT_SHIFT(0x0A), AE1799_SLOT_SHIFT(0x0A), this); }
-		void Unk_0B(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(AE1799_SLOT_SHIFT(0x0B), AE1799_SLOT_SHIFT(0x0B), this); }
-		void Unk_0C(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(AE1799_SLOT_SHIFT(0x0C), AE1799_SLOT_SHIFT(0x0C), this); }
-		void Unk_0D(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(AE1799_SLOT_SHIFT(0x0D), AE1799_SLOT_SHIFT(0x0D), this); }
-		void Unk_0E(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(AE1799_SLOT_SHIFT(0x0E), AE1799_SLOT_SHIFT(0x0E), this); }
-		void Unk_0F(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(AE1799_SLOT_SHIFT(0x0F), AE1799_SLOT_SHIFT(0x0F), this); }
-		void Unk_10(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(AE1799_SLOT_SHIFT(0x10), AE1799_SLOT_SHIFT(0x10), this); }
-		void Unk_11(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(AE1799_SLOT_SHIFT(0x11), AE1799_SLOT_SHIFT(0x11), this); }
+		void Unk_06(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x06, 6), REL::AE1799Shift(0x06, 6), this); }
+		void Unk_07(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x07, 6), REL::AE1799Shift(0x07, 6), this); }
+		void Unk_08(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x08, 6), REL::AE1799Shift(0x08, 6), this); }
+		void Unk_09(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x09, 6), REL::AE1799Shift(0x09, 6), this); }
+		void Unk_0A(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0A, 6), REL::AE1799Shift(0x0A, 6), this); }
+		void Unk_0B(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0B, 6), REL::AE1799Shift(0x0B, 6), this); }
+		void Unk_0C(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0C, 6), REL::AE1799Shift(0x0C, 6), this); }
+		void Unk_0D(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0D, 6), REL::AE1799Shift(0x0D, 6), this); }
+		void Unk_0E(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0E, 6), REL::AE1799Shift(0x0E, 6), this); }
+		void Unk_0F(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0F, 6), REL::AE1799Shift(0x0F, 6), this); }
+		void Unk_10(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x10, 6), REL::AE1799Shift(0x10, 6), this); }
+		void Unk_11(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x11, 6), REL::AE1799Shift(0x11, 6), this); }
 #endif
-#undef AE1799_SLOT_SHIFT
 
 		// members
 		std::uint8_t  unk060;              // 060

--- a/include/RE/B/BSSaveDataSystemUtility.h
+++ b/include/RE/B/BSSaveDataSystemUtility.h
@@ -137,20 +137,20 @@ namespace RE
 		static constexpr std::size_t kAE1799AddedVFuncCount = 6;  // matches Unk_05AE..Unk_0AAE above
 		void                         Unk_05(void)
 		{
-			REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x05, kAE1799AddedVFuncCount), REL::AE1799Shift(0x05, kAE1799AddedVFuncCount), this);
+			REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::VersionShift(0x05, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x05, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this);
 		}
-		void Unk_06(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x06, kAE1799AddedVFuncCount), REL::AE1799Shift(0x06, kAE1799AddedVFuncCount), this); }
-		void Unk_07(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x07, kAE1799AddedVFuncCount), REL::AE1799Shift(0x07, kAE1799AddedVFuncCount), this); }
-		void Unk_08(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x08, kAE1799AddedVFuncCount), REL::AE1799Shift(0x08, kAE1799AddedVFuncCount), this); }
-		void Unk_09(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x09, kAE1799AddedVFuncCount), REL::AE1799Shift(0x09, kAE1799AddedVFuncCount), this); }
-		void Unk_0A(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0A, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0A, kAE1799AddedVFuncCount), this); }
-		void Unk_0B(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0B, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0B, kAE1799AddedVFuncCount), this); }
-		void Unk_0C(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0C, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0C, kAE1799AddedVFuncCount), this); }
-		void Unk_0D(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0D, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0D, kAE1799AddedVFuncCount), this); }
-		void Unk_0E(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0E, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0E, kAE1799AddedVFuncCount), this); }
-		void Unk_0F(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x0F, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0F, kAE1799AddedVFuncCount), this); }
-		void Unk_10(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x10, kAE1799AddedVFuncCount), REL::AE1799Shift(0x10, kAE1799AddedVFuncCount), this); }
-		void Unk_11(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::AE1799Shift(0x11, kAE1799AddedVFuncCount), REL::AE1799Shift(0x11, kAE1799AddedVFuncCount), this); }
+		void Unk_06(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::VersionShift(0x06, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x06, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_07(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::VersionShift(0x07, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x07, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_08(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::VersionShift(0x08, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x08, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_09(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::VersionShift(0x09, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x09, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_0A(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::VersionShift(0x0A, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x0A, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_0B(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::VersionShift(0x0B, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x0B, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_0C(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::VersionShift(0x0C, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x0C, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_0D(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::VersionShift(0x0D, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x0D, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_0E(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::VersionShift(0x0E, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x0E, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_0F(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::VersionShift(0x0F, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x0F, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_10(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::VersionShift(0x10, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x10, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_11(void) { REL::RelocateVirtual<void(BSSaveDataSystemUtility*)>(REL::VersionShift(0x11, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x11, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
 #endif
 
 		// members

--- a/include/RE/B/BSSystemUtility.h
+++ b/include/RE/B/BSSystemUtility.h
@@ -2,6 +2,7 @@
 
 #include "RE/B/BSTEvent.h"
 #include "REL/Relocation.h"
+#include "REL/RuntimeDataAccessors.h"
 #include "SKSE/Version.h"
 
 namespace RE
@@ -20,8 +21,6 @@ namespace RE
 		BSEventNotifyControl ProcessEvent(const BSGamepadEvent* a_event, BSTEventSource<BSGamepadEvent>* a_eventSource) override;  // 01
 
 #ifdef ENABLE_SKYRIM_AE
-#	define AE1799_SLOT_SHIFT(idx) (REL::Module::IsAtLeast(SKSE::RUNTIME_SSE_1_7_99) ? (idx) + 1 : (idx))
-
 		bool Unk_02AE(void* a_result)
 		{
 			if (!REL::Module::IsAtLeast(SKSE::RUNTIME_SSE_1_7_99)) {
@@ -30,8 +29,6 @@ namespace RE
 			REL::RelocateVirtual<void(BSSystemUtility*, void*)>(0x02, 0x02, this, a_result);
 			return true;
 		}
-#else
-#	define AE1799_SLOT_SHIFT(idx) (idx)
 #endif
 
 #ifndef ENABLE_SKYRIM_AE
@@ -55,32 +52,31 @@ namespace RE
 #else
 		void GetAuthenticationInfo(char*& a_userAuthID, std::uint64_t& a_size)
 		{
-			REL::RelocateVirtual<void(BSSystemUtility*, char*&, std::uint64_t&)>(AE1799_SLOT_SHIFT(0x02), AE1799_SLOT_SHIFT(0x02), this, a_userAuthID, a_size);
+			REL::RelocateVirtual<void(BSSystemUtility*, char*&, std::uint64_t&)>(REL::AE1799Shift(0x02, 1), REL::AE1799Shift(0x02, 1), this, a_userAuthID, a_size);
 		}
-		void Unk_03(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(AE1799_SLOT_SHIFT(0x03), AE1799_SLOT_SHIFT(0x03), this); }
-		void DoInitialize() { REL::RelocateVirtual<void(BSSystemUtility*)>(AE1799_SLOT_SHIFT(0x04), AE1799_SLOT_SHIFT(0x04), this); }
-		void Unk_05(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(AE1799_SLOT_SHIFT(0x05), AE1799_SLOT_SHIFT(0x05), this); }
-		void DoUpdate() { REL::RelocateVirtual<void(BSSystemUtility*)>(AE1799_SLOT_SHIFT(0x06), AE1799_SLOT_SHIFT(0x06), this); }
-		void Unk_07(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(AE1799_SLOT_SHIFT(0x07), AE1799_SLOT_SHIFT(0x07), this); }
+		void Unk_03(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x03, 1), REL::AE1799Shift(0x03, 1), this); }
+		void DoInitialize() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x04, 1), REL::AE1799Shift(0x04, 1), this); }
+		void Unk_05(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x05, 1), REL::AE1799Shift(0x05, 1), this); }
+		void DoUpdate() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x06, 1), REL::AE1799Shift(0x06, 1), this); }
+		void Unk_07(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x07, 1), REL::AE1799Shift(0x07, 1), this); }
 		void DoGetUserName(char* a_buffer, std::uint64_t a_size)
 		{
-			REL::RelocateVirtual<void(BSSystemUtility*, char*, std::uint64_t)>(AE1799_SLOT_SHIFT(0x08), AE1799_SLOT_SHIFT(0x08), this, a_buffer, a_size);
+			REL::RelocateVirtual<void(BSSystemUtility*, char*, std::uint64_t)>(REL::AE1799Shift(0x08, 1), REL::AE1799Shift(0x08, 1), this, a_buffer, a_size);
 		}
-		void Unk_09(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(AE1799_SLOT_SHIFT(0x09), AE1799_SLOT_SHIFT(0x09), this); }
-		void Unk_0A(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(AE1799_SLOT_SHIFT(0x0A), AE1799_SLOT_SHIFT(0x0A), this); }
-		void Unk_0B(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(AE1799_SLOT_SHIFT(0x0B), AE1799_SLOT_SHIFT(0x0B), this); }
-		void Unk_0C(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(AE1799_SLOT_SHIFT(0x0C), AE1799_SLOT_SHIFT(0x0C), this); }
+		void Unk_09(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x09, 1), REL::AE1799Shift(0x09, 1), this); }
+		void Unk_0A(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0A, 1), REL::AE1799Shift(0x0A, 1), this); }
+		void Unk_0B(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0B, 1), REL::AE1799Shift(0x0B, 1), this); }
+		void Unk_0C(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0C, 1), REL::AE1799Shift(0x0C, 1), this); }
 		void DoGetComputerName(char* a_buffer, std::uint64_t a_size)
 		{
-			REL::RelocateVirtual<void(BSSystemUtility*, char*, std::uint64_t)>(AE1799_SLOT_SHIFT(0x0D), AE1799_SLOT_SHIFT(0x0D), this, a_buffer, a_size);
+			REL::RelocateVirtual<void(BSSystemUtility*, char*, std::uint64_t)>(REL::AE1799Shift(0x0D, 1), REL::AE1799Shift(0x0D, 1), this, a_buffer, a_size);
 		}
-		void Unk_0E(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(AE1799_SLOT_SHIFT(0x0E), AE1799_SLOT_SHIFT(0x0E), this); }
-		void Unk_0F(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(AE1799_SLOT_SHIFT(0x0F), AE1799_SLOT_SHIFT(0x0F), this); }
-		void DoAuthenticateUser() { REL::RelocateVirtual<void(BSSystemUtility*)>(AE1799_SLOT_SHIFT(0x10), AE1799_SLOT_SHIFT(0x10), this); }
-		void Unk_11(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(AE1799_SLOT_SHIFT(0x11), AE1799_SLOT_SHIFT(0x11), this); }
-		bool Unk_12() { return REL::RelocateVirtual<bool(BSSystemUtility*)>(AE1799_SLOT_SHIFT(0x12), AE1799_SLOT_SHIFT(0x12), this); }  // added in 1.6.1130
+		void Unk_0E(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0E, 1), REL::AE1799Shift(0x0E, 1), this); }
+		void Unk_0F(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0F, 1), REL::AE1799Shift(0x0F, 1), this); }
+		void DoAuthenticateUser() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x10, 1), REL::AE1799Shift(0x10, 1), this); }
+		void Unk_11(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x11, 1), REL::AE1799Shift(0x11, 1), this); }
+		bool Unk_12() { return REL::RelocateVirtual<bool(BSSystemUtility*)>(REL::AE1799Shift(0x12, 1), REL::AE1799Shift(0x12, 1), this); }  // added in 1.6.1130
 #endif
-#undef AE1799_SLOT_SHIFT
 
 		// members
 		std::uint64_t unk060[24];  // 060

--- a/include/RE/B/BSSystemUtility.h
+++ b/include/RE/B/BSSystemUtility.h
@@ -53,30 +53,30 @@ namespace RE
 		static constexpr std::size_t kAE1799AddedVFuncCount = 1;  // matches Unk_02AE above
 		void                         GetAuthenticationInfo(char*& a_userAuthID, std::uint64_t& a_size)
 		{
-			REL::RelocateVirtual<void(BSSystemUtility*, char*&, std::uint64_t&)>(REL::AE1799Shift(0x02, kAE1799AddedVFuncCount), REL::AE1799Shift(0x02, kAE1799AddedVFuncCount), this, a_userAuthID, a_size);
+			REL::RelocateVirtual<void(BSSystemUtility*, char*&, std::uint64_t&)>(REL::VersionShift(0x02, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x02, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this, a_userAuthID, a_size);
 		}
-		void Unk_03(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x03, kAE1799AddedVFuncCount), REL::AE1799Shift(0x03, kAE1799AddedVFuncCount), this); }
-		void DoInitialize() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x04, kAE1799AddedVFuncCount), REL::AE1799Shift(0x04, kAE1799AddedVFuncCount), this); }
-		void Unk_05(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x05, kAE1799AddedVFuncCount), REL::AE1799Shift(0x05, kAE1799AddedVFuncCount), this); }
-		void DoUpdate() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x06, kAE1799AddedVFuncCount), REL::AE1799Shift(0x06, kAE1799AddedVFuncCount), this); }
-		void Unk_07(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x07, kAE1799AddedVFuncCount), REL::AE1799Shift(0x07, kAE1799AddedVFuncCount), this); }
+		void Unk_03(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::VersionShift(0x03, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x03, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void DoInitialize() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::VersionShift(0x04, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x04, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_05(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::VersionShift(0x05, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x05, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void DoUpdate() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::VersionShift(0x06, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x06, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_07(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::VersionShift(0x07, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x07, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
 		void DoGetUserName(char* a_buffer, std::uint64_t a_size)
 		{
-			REL::RelocateVirtual<void(BSSystemUtility*, char*, std::uint64_t)>(REL::AE1799Shift(0x08, kAE1799AddedVFuncCount), REL::AE1799Shift(0x08, kAE1799AddedVFuncCount), this, a_buffer, a_size);
+			REL::RelocateVirtual<void(BSSystemUtility*, char*, std::uint64_t)>(REL::VersionShift(0x08, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x08, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this, a_buffer, a_size);
 		}
-		void Unk_09(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x09, kAE1799AddedVFuncCount), REL::AE1799Shift(0x09, kAE1799AddedVFuncCount), this); }
-		void Unk_0A(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0A, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0A, kAE1799AddedVFuncCount), this); }
-		void Unk_0B(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0B, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0B, kAE1799AddedVFuncCount), this); }
-		void Unk_0C(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0C, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0C, kAE1799AddedVFuncCount), this); }
+		void Unk_09(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::VersionShift(0x09, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x09, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_0A(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::VersionShift(0x0A, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x0A, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_0B(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::VersionShift(0x0B, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x0B, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_0C(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::VersionShift(0x0C, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x0C, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
 		void DoGetComputerName(char* a_buffer, std::uint64_t a_size)
 		{
-			REL::RelocateVirtual<void(BSSystemUtility*, char*, std::uint64_t)>(REL::AE1799Shift(0x0D, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0D, kAE1799AddedVFuncCount), this, a_buffer, a_size);
+			REL::RelocateVirtual<void(BSSystemUtility*, char*, std::uint64_t)>(REL::VersionShift(0x0D, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x0D, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this, a_buffer, a_size);
 		}
-		void Unk_0E(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0E, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0E, kAE1799AddedVFuncCount), this); }
-		void Unk_0F(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0F, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0F, kAE1799AddedVFuncCount), this); }
-		void DoAuthenticateUser() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x10, kAE1799AddedVFuncCount), REL::AE1799Shift(0x10, kAE1799AddedVFuncCount), this); }
-		void Unk_11(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x11, kAE1799AddedVFuncCount), REL::AE1799Shift(0x11, kAE1799AddedVFuncCount), this); }
-		bool Unk_12() { return REL::RelocateVirtual<bool(BSSystemUtility*)>(REL::AE1799Shift(0x12, kAE1799AddedVFuncCount), REL::AE1799Shift(0x12, kAE1799AddedVFuncCount), this); }  // added in 1.6.1130
+		void Unk_0E(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::VersionShift(0x0E, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x0E, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_0F(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::VersionShift(0x0F, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x0F, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void DoAuthenticateUser() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::VersionShift(0x10, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x10, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		void Unk_11(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::VersionShift(0x11, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x11, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }
+		bool Unk_12() { return REL::RelocateVirtual<bool(BSSystemUtility*)>(REL::VersionShift(0x12, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), REL::VersionShift(0x12, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), this); }  // added in 1.6.1130
 #endif
 
 		// members

--- a/include/RE/B/BSSystemUtility.h
+++ b/include/RE/B/BSSystemUtility.h
@@ -50,32 +50,33 @@ namespace RE
 		virtual void Unk_11(void);                                                       // 11
 		virtual bool Unk_12();                                                           // 12 - added in 1.6.1130
 #else
-		void GetAuthenticationInfo(char*& a_userAuthID, std::uint64_t& a_size)
+		static constexpr std::size_t kAE1799AddedVFuncCount = 1;  // matches Unk_02AE above
+		void                         GetAuthenticationInfo(char*& a_userAuthID, std::uint64_t& a_size)
 		{
-			REL::RelocateVirtual<void(BSSystemUtility*, char*&, std::uint64_t&)>(REL::AE1799Shift(0x02, 1), REL::AE1799Shift(0x02, 1), this, a_userAuthID, a_size);
+			REL::RelocateVirtual<void(BSSystemUtility*, char*&, std::uint64_t&)>(REL::AE1799Shift(0x02, kAE1799AddedVFuncCount), REL::AE1799Shift(0x02, kAE1799AddedVFuncCount), this, a_userAuthID, a_size);
 		}
-		void Unk_03(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x03, 1), REL::AE1799Shift(0x03, 1), this); }
-		void DoInitialize() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x04, 1), REL::AE1799Shift(0x04, 1), this); }
-		void Unk_05(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x05, 1), REL::AE1799Shift(0x05, 1), this); }
-		void DoUpdate() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x06, 1), REL::AE1799Shift(0x06, 1), this); }
-		void Unk_07(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x07, 1), REL::AE1799Shift(0x07, 1), this); }
+		void Unk_03(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x03, kAE1799AddedVFuncCount), REL::AE1799Shift(0x03, kAE1799AddedVFuncCount), this); }
+		void DoInitialize() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x04, kAE1799AddedVFuncCount), REL::AE1799Shift(0x04, kAE1799AddedVFuncCount), this); }
+		void Unk_05(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x05, kAE1799AddedVFuncCount), REL::AE1799Shift(0x05, kAE1799AddedVFuncCount), this); }
+		void DoUpdate() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x06, kAE1799AddedVFuncCount), REL::AE1799Shift(0x06, kAE1799AddedVFuncCount), this); }
+		void Unk_07(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x07, kAE1799AddedVFuncCount), REL::AE1799Shift(0x07, kAE1799AddedVFuncCount), this); }
 		void DoGetUserName(char* a_buffer, std::uint64_t a_size)
 		{
-			REL::RelocateVirtual<void(BSSystemUtility*, char*, std::uint64_t)>(REL::AE1799Shift(0x08, 1), REL::AE1799Shift(0x08, 1), this, a_buffer, a_size);
+			REL::RelocateVirtual<void(BSSystemUtility*, char*, std::uint64_t)>(REL::AE1799Shift(0x08, kAE1799AddedVFuncCount), REL::AE1799Shift(0x08, kAE1799AddedVFuncCount), this, a_buffer, a_size);
 		}
-		void Unk_09(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x09, 1), REL::AE1799Shift(0x09, 1), this); }
-		void Unk_0A(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0A, 1), REL::AE1799Shift(0x0A, 1), this); }
-		void Unk_0B(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0B, 1), REL::AE1799Shift(0x0B, 1), this); }
-		void Unk_0C(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0C, 1), REL::AE1799Shift(0x0C, 1), this); }
+		void Unk_09(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x09, kAE1799AddedVFuncCount), REL::AE1799Shift(0x09, kAE1799AddedVFuncCount), this); }
+		void Unk_0A(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0A, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0A, kAE1799AddedVFuncCount), this); }
+		void Unk_0B(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0B, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0B, kAE1799AddedVFuncCount), this); }
+		void Unk_0C(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0C, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0C, kAE1799AddedVFuncCount), this); }
 		void DoGetComputerName(char* a_buffer, std::uint64_t a_size)
 		{
-			REL::RelocateVirtual<void(BSSystemUtility*, char*, std::uint64_t)>(REL::AE1799Shift(0x0D, 1), REL::AE1799Shift(0x0D, 1), this, a_buffer, a_size);
+			REL::RelocateVirtual<void(BSSystemUtility*, char*, std::uint64_t)>(REL::AE1799Shift(0x0D, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0D, kAE1799AddedVFuncCount), this, a_buffer, a_size);
 		}
-		void Unk_0E(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0E, 1), REL::AE1799Shift(0x0E, 1), this); }
-		void Unk_0F(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0F, 1), REL::AE1799Shift(0x0F, 1), this); }
-		void DoAuthenticateUser() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x10, 1), REL::AE1799Shift(0x10, 1), this); }
-		void Unk_11(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x11, 1), REL::AE1799Shift(0x11, 1), this); }
-		bool Unk_12() { return REL::RelocateVirtual<bool(BSSystemUtility*)>(REL::AE1799Shift(0x12, 1), REL::AE1799Shift(0x12, 1), this); }  // added in 1.6.1130
+		void Unk_0E(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0E, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0E, kAE1799AddedVFuncCount), this); }
+		void Unk_0F(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x0F, kAE1799AddedVFuncCount), REL::AE1799Shift(0x0F, kAE1799AddedVFuncCount), this); }
+		void DoAuthenticateUser() { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x10, kAE1799AddedVFuncCount), REL::AE1799Shift(0x10, kAE1799AddedVFuncCount), this); }
+		void Unk_11(void) { REL::RelocateVirtual<void(BSSystemUtility*)>(REL::AE1799Shift(0x11, kAE1799AddedVFuncCount), REL::AE1799Shift(0x11, kAE1799AddedVFuncCount), this); }
+		bool Unk_12() { return REL::RelocateVirtual<bool(BSSystemUtility*)>(REL::AE1799Shift(0x12, kAE1799AddedVFuncCount), REL::AE1799Shift(0x12, kAE1799AddedVFuncCount), this); }  // added in 1.6.1130
 #endif
 
 		// members

--- a/include/RE/H/HeldStateHandler.h
+++ b/include/RE/H/HeldStateHandler.h
@@ -17,8 +17,7 @@ namespace RE
 		virtual void UpdateHeldStateActive(const ButtonEvent* a_event);  // 05
 		virtual void SetHeldStateActive(bool a_flag);                    // 06
 #else
-		// Inherits PlayerInputHandler::kAE1799AddedVFuncCount -- same base-class
-		// vtable this class's own slots shift against.
+		// Same base-class vtable, so PlayerInputHandler's delta applies here too.
 		void UpdateHeldStateActive(const ButtonEvent* a_event)
 		{
 			REL::RelocateVirtual<void(HeldStateHandler*, const ButtonEvent*)>(REL::VersionShift(0x05, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), 0x05, this, a_event);

--- a/include/RE/H/HeldStateHandler.h
+++ b/include/RE/H/HeldStateHandler.h
@@ -17,20 +17,14 @@ namespace RE
 		virtual void UpdateHeldStateActive(const ButtonEvent* a_event);  // 05
 		virtual void SetHeldStateActive(bool a_flag);                    // 06
 #else
-#	ifdef ENABLE_SKYRIM_AE
-#		define AE1799_SLOT_SHIFT(idx) (REL::Module::IsAtLeast(SKSE::RUNTIME_SSE_1_7_99) ? (idx) + 2 : (idx))
-#	else
-#		define AE1799_SLOT_SHIFT(idx) (idx)
-#	endif
 		void UpdateHeldStateActive(const ButtonEvent* a_event)
 		{
-			REL::RelocateVirtual<void(HeldStateHandler*, const ButtonEvent*)>(AE1799_SLOT_SHIFT(0x05), 0x05, this, a_event);
+			REL::RelocateVirtual<void(HeldStateHandler*, const ButtonEvent*)>(REL::AE1799Shift(0x05, 2), 0x05, this, a_event);
 		}
 		void SetHeldStateActive(bool a_flag)
 		{
-			REL::RelocateVirtual<void(HeldStateHandler*, bool)>(AE1799_SLOT_SHIFT(0x06), 0x06, this, a_flag);
+			REL::RelocateVirtual<void(HeldStateHandler*, bool)>(REL::AE1799Shift(0x06, 2), 0x06, this, a_flag);
 		}
-#	undef AE1799_SLOT_SHIFT
 #endif
 
 		// members

--- a/include/RE/H/HeldStateHandler.h
+++ b/include/RE/H/HeldStateHandler.h
@@ -17,13 +17,15 @@ namespace RE
 		virtual void UpdateHeldStateActive(const ButtonEvent* a_event);  // 05
 		virtual void SetHeldStateActive(bool a_flag);                    // 06
 #else
+		// Inherits PlayerInputHandler::kAE1799AddedVFuncCount -- same base-class
+		// vtable this class's own slots shift against.
 		void UpdateHeldStateActive(const ButtonEvent* a_event)
 		{
-			REL::RelocateVirtual<void(HeldStateHandler*, const ButtonEvent*)>(REL::AE1799Shift(0x05, 2), 0x05, this, a_event);
+			REL::RelocateVirtual<void(HeldStateHandler*, const ButtonEvent*)>(REL::AE1799Shift(0x05, kAE1799AddedVFuncCount), 0x05, this, a_event);
 		}
 		void SetHeldStateActive(bool a_flag)
 		{
-			REL::RelocateVirtual<void(HeldStateHandler*, bool)>(REL::AE1799Shift(0x06, 2), 0x06, this, a_flag);
+			REL::RelocateVirtual<void(HeldStateHandler*, bool)>(REL::AE1799Shift(0x06, kAE1799AddedVFuncCount), 0x06, this, a_flag);
 		}
 #endif
 

--- a/include/RE/H/HeldStateHandler.h
+++ b/include/RE/H/HeldStateHandler.h
@@ -21,11 +21,11 @@ namespace RE
 		// vtable this class's own slots shift against.
 		void UpdateHeldStateActive(const ButtonEvent* a_event)
 		{
-			REL::RelocateVirtual<void(HeldStateHandler*, const ButtonEvent*)>(REL::AE1799Shift(0x05, kAE1799AddedVFuncCount), 0x05, this, a_event);
+			REL::RelocateVirtual<void(HeldStateHandler*, const ButtonEvent*)>(REL::VersionShift(0x05, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), 0x05, this, a_event);
 		}
 		void SetHeldStateActive(bool a_flag)
 		{
-			REL::RelocateVirtual<void(HeldStateHandler*, bool)>(REL::AE1799Shift(0x06, kAE1799AddedVFuncCount), 0x06, this, a_flag);
+			REL::RelocateVirtual<void(HeldStateHandler*, bool)>(REL::VersionShift(0x06, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), 0x06, this, a_flag);
 		}
 #endif
 

--- a/include/RE/M/MenuEventHandler.h
+++ b/include/RE/M/MenuEventHandler.h
@@ -43,19 +43,19 @@ namespace RE
 
 		bool ProcessKinect(KinectEvent* a_event)
 		{
-			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessKinect)>(REL::AE1799Shift(0x02, kAE1799AddedVFuncCount), 0x05, this, a_event);
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessKinect)>(REL::VersionShift(0x02, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), 0x05, this, a_event);
 		}
 		bool ProcessThumbstick(ThumbstickEvent* a_event)
 		{
-			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessThumbstick)>(REL::AE1799Shift(0x03, kAE1799AddedVFuncCount), 0x06, this, a_event);
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessThumbstick)>(REL::VersionShift(0x03, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), 0x06, this, a_event);
 		}
 		bool ProcessMouseMove(MouseMoveEvent* a_event)
 		{
-			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessMouseMove)>(REL::AE1799Shift(0x04, kAE1799AddedVFuncCount), 0x07, this, a_event);
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessMouseMove)>(REL::VersionShift(0x04, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), 0x07, this, a_event);
 		}
 		bool ProcessButton(ButtonEvent* a_event)
 		{
-			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessButton)>(REL::AE1799Shift(0x05, kAE1799AddedVFuncCount), 0x08, this, a_event);
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessButton)>(REL::VersionShift(0x05, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), 0x08, this, a_event);
 		}
 
 #	ifdef ENABLE_SKYRIM_AE

--- a/include/RE/M/MenuEventHandler.h
+++ b/include/RE/M/MenuEventHandler.h
@@ -39,21 +39,23 @@ namespace RE
 		virtual bool ProcessMouseMove(MouseMoveEvent* a_event);                            // VR 07 - { return false; }
 		virtual bool ProcessButton(ButtonEvent* a_event);                                  // VR 08 - { return false; }
 #else
+		static constexpr std::size_t kAE1799AddedVFuncCount = 2;  // matches ProcessMotionGesture/ProcessSixaxis below
+
 		bool ProcessKinect(KinectEvent* a_event)
 		{
-			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessKinect)>(REL::AE1799Shift(0x02, 2), 0x05, this, a_event);
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessKinect)>(REL::AE1799Shift(0x02, kAE1799AddedVFuncCount), 0x05, this, a_event);
 		}
 		bool ProcessThumbstick(ThumbstickEvent* a_event)
 		{
-			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessThumbstick)>(REL::AE1799Shift(0x03, 2), 0x06, this, a_event);
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessThumbstick)>(REL::AE1799Shift(0x03, kAE1799AddedVFuncCount), 0x06, this, a_event);
 		}
 		bool ProcessMouseMove(MouseMoveEvent* a_event)
 		{
-			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessMouseMove)>(REL::AE1799Shift(0x04, 2), 0x07, this, a_event);
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessMouseMove)>(REL::AE1799Shift(0x04, kAE1799AddedVFuncCount), 0x07, this, a_event);
 		}
 		bool ProcessButton(ButtonEvent* a_event)
 		{
-			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessButton)>(REL::AE1799Shift(0x05, 2), 0x08, this, a_event);
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessButton)>(REL::AE1799Shift(0x05, kAE1799AddedVFuncCount), 0x08, this, a_event);
 		}
 
 #	ifdef ENABLE_SKYRIM_AE

--- a/include/RE/M/MenuEventHandler.h
+++ b/include/RE/M/MenuEventHandler.h
@@ -2,6 +2,7 @@
 
 #include "RE/B/BSIntrusiveRefCounted.h"
 #include "REL/Relocation.h"
+#include "REL/RuntimeDataAccessors.h"
 #include "SKSE/Version.h"
 
 namespace RE
@@ -38,26 +39,21 @@ namespace RE
 		virtual bool ProcessMouseMove(MouseMoveEvent* a_event);                            // VR 07 - { return false; }
 		virtual bool ProcessButton(ButtonEvent* a_event);                                  // VR 08 - { return false; }
 #else
-#	ifdef ENABLE_SKYRIM_AE
-#		define AE1799_SLOT_SHIFT(idx) (REL::Module::IsAtLeast(SKSE::RUNTIME_SSE_1_7_99) ? (idx) + 2 : (idx))
-#	else
-#		define AE1799_SLOT_SHIFT(idx) (idx)
-#	endif
 		bool ProcessKinect(KinectEvent* a_event)
 		{
-			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessKinect)>(AE1799_SLOT_SHIFT(0x02), 0x05, this, a_event);
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessKinect)>(REL::AE1799Shift(0x02, 2), 0x05, this, a_event);
 		}
 		bool ProcessThumbstick(ThumbstickEvent* a_event)
 		{
-			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessThumbstick)>(AE1799_SLOT_SHIFT(0x03), 0x06, this, a_event);
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessThumbstick)>(REL::AE1799Shift(0x03, 2), 0x06, this, a_event);
 		}
 		bool ProcessMouseMove(MouseMoveEvent* a_event)
 		{
-			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessMouseMove)>(AE1799_SLOT_SHIFT(0x04), 0x07, this, a_event);
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessMouseMove)>(REL::AE1799Shift(0x04, 2), 0x07, this, a_event);
 		}
 		bool ProcessButton(ButtonEvent* a_event)
 		{
-			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessButton)>(AE1799_SLOT_SHIFT(0x05), 0x08, this, a_event);
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessButton)>(REL::AE1799Shift(0x05, 2), 0x08, this, a_event);
 		}
 
 #	ifdef ENABLE_SKYRIM_AE
@@ -76,7 +72,6 @@ namespace RE
 			return REL::RelocateVirtual<bool(MenuEventHandler*, SixaxisEvent*)>(0x03, 0x03, this, a_event);
 		}
 #	endif
-#	undef AE1799_SLOT_SHIFT
 
 		bool ProcessVrWandTouchpadSwipe(VrWandTouchpadSwipeEvent* a_event)
 		{

--- a/include/RE/P/PlayerInputHandler.h
+++ b/include/RE/P/PlayerInputHandler.h
@@ -34,17 +34,19 @@ namespace RE
 		virtual void Unk_05(void);                                                                                               // 05
 		virtual void Unk_06(void);                                                                                               // 06
 #else
+		static constexpr std::size_t kAE1799AddedVFuncCount = 2;  // matches ProcessMotionGesture/ProcessSixaxis below
+
 		void ProcessThumbstick(ThumbstickEvent* a_event, PlayerControlsData* a_data)
 		{
-			REL::RelocateVirtual<void(PlayerInputHandler*, ThumbstickEvent*, PlayerControlsData*)>(REL::AE1799Shift(0x02, 2), 0x02, this, a_event, a_data);
+			REL::RelocateVirtual<void(PlayerInputHandler*, ThumbstickEvent*, PlayerControlsData*)>(REL::AE1799Shift(0x02, kAE1799AddedVFuncCount), 0x02, this, a_event, a_data);
 		}
 		void ProcessMouseMove(MouseMoveEvent* a_event, PlayerControlsData* a_data)
 		{
-			REL::RelocateVirtual<void(PlayerInputHandler*, MouseMoveEvent*, PlayerControlsData*)>(REL::AE1799Shift(0x03, 2), 0x03, this, a_event, a_data);
+			REL::RelocateVirtual<void(PlayerInputHandler*, MouseMoveEvent*, PlayerControlsData*)>(REL::AE1799Shift(0x03, kAE1799AddedVFuncCount), 0x03, this, a_event, a_data);
 		}
 		void ProcessButton(ButtonEvent* a_event, PlayerControlsData* a_data)
 		{
-			REL::RelocateVirtual<void(PlayerInputHandler*, ButtonEvent*, PlayerControlsData*)>(REL::AE1799Shift(0x04, 2), 0x04, this, a_event, a_data);
+			REL::RelocateVirtual<void(PlayerInputHandler*, ButtonEvent*, PlayerControlsData*)>(REL::AE1799Shift(0x04, kAE1799AddedVFuncCount), 0x04, this, a_event, a_data);
 		}
 
 #	ifdef ENABLE_SKYRIM_AE

--- a/include/RE/P/PlayerInputHandler.h
+++ b/include/RE/P/PlayerInputHandler.h
@@ -38,15 +38,15 @@ namespace RE
 
 		void ProcessThumbstick(ThumbstickEvent* a_event, PlayerControlsData* a_data)
 		{
-			REL::RelocateVirtual<void(PlayerInputHandler*, ThumbstickEvent*, PlayerControlsData*)>(REL::AE1799Shift(0x02, kAE1799AddedVFuncCount), 0x02, this, a_event, a_data);
+			REL::RelocateVirtual<void(PlayerInputHandler*, ThumbstickEvent*, PlayerControlsData*)>(REL::VersionShift(0x02, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), 0x02, this, a_event, a_data);
 		}
 		void ProcessMouseMove(MouseMoveEvent* a_event, PlayerControlsData* a_data)
 		{
-			REL::RelocateVirtual<void(PlayerInputHandler*, MouseMoveEvent*, PlayerControlsData*)>(REL::AE1799Shift(0x03, kAE1799AddedVFuncCount), 0x03, this, a_event, a_data);
+			REL::RelocateVirtual<void(PlayerInputHandler*, MouseMoveEvent*, PlayerControlsData*)>(REL::VersionShift(0x03, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), 0x03, this, a_event, a_data);
 		}
 		void ProcessButton(ButtonEvent* a_event, PlayerControlsData* a_data)
 		{
-			REL::RelocateVirtual<void(PlayerInputHandler*, ButtonEvent*, PlayerControlsData*)>(REL::AE1799Shift(0x04, kAE1799AddedVFuncCount), 0x04, this, a_event, a_data);
+			REL::RelocateVirtual<void(PlayerInputHandler*, ButtonEvent*, PlayerControlsData*)>(REL::VersionShift(0x04, kAE1799AddedVFuncCount, SKSE::RUNTIME_SSE_1_7_99), 0x04, this, a_event, a_data);
 		}
 
 #	ifdef ENABLE_SKYRIM_AE

--- a/include/RE/P/PlayerInputHandler.h
+++ b/include/RE/P/PlayerInputHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "RE/B/BSFixedString.h"
 #include "REL/Relocation.h"
+#include "REL/RuntimeDataAccessors.h"
 #include "SKSE/Version.h"
 
 namespace RE
@@ -33,22 +34,17 @@ namespace RE
 		virtual void Unk_05(void);                                                                                               // 05
 		virtual void Unk_06(void);                                                                                               // 06
 #else
-#	ifdef ENABLE_SKYRIM_AE
-#		define AE1799_SLOT_SHIFT(idx) (REL::Module::IsAtLeast(SKSE::RUNTIME_SSE_1_7_99) ? (idx) + 2 : (idx))
-#	else
-#		define AE1799_SLOT_SHIFT(idx) (idx)
-#	endif
 		void ProcessThumbstick(ThumbstickEvent* a_event, PlayerControlsData* a_data)
 		{
-			REL::RelocateVirtual<void(PlayerInputHandler*, ThumbstickEvent*, PlayerControlsData*)>(AE1799_SLOT_SHIFT(0x02), 0x02, this, a_event, a_data);
+			REL::RelocateVirtual<void(PlayerInputHandler*, ThumbstickEvent*, PlayerControlsData*)>(REL::AE1799Shift(0x02, 2), 0x02, this, a_event, a_data);
 		}
 		void ProcessMouseMove(MouseMoveEvent* a_event, PlayerControlsData* a_data)
 		{
-			REL::RelocateVirtual<void(PlayerInputHandler*, MouseMoveEvent*, PlayerControlsData*)>(AE1799_SLOT_SHIFT(0x03), 0x03, this, a_event, a_data);
+			REL::RelocateVirtual<void(PlayerInputHandler*, MouseMoveEvent*, PlayerControlsData*)>(REL::AE1799Shift(0x03, 2), 0x03, this, a_event, a_data);
 		}
 		void ProcessButton(ButtonEvent* a_event, PlayerControlsData* a_data)
 		{
-			REL::RelocateVirtual<void(PlayerInputHandler*, ButtonEvent*, PlayerControlsData*)>(AE1799_SLOT_SHIFT(0x04), 0x04, this, a_event, a_data);
+			REL::RelocateVirtual<void(PlayerInputHandler*, ButtonEvent*, PlayerControlsData*)>(REL::AE1799Shift(0x04, 2), 0x04, this, a_event, a_data);
 		}
 
 #	ifdef ENABLE_SKYRIM_AE
@@ -67,7 +63,6 @@ namespace RE
 			return REL::RelocateVirtual<bool(PlayerInputHandler*, SixaxisEvent*)>(0x03, 0x03, this, a_event);
 		}
 #	endif
-#	undef AE1799_SLOT_SHIFT
 
 		void Unk_05(void)
 		{

--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -290,9 +290,6 @@ namespace RE
             RUNTIME_DATA2_CONTENT
 		};
 
-		// See the base-class-list comment above: the game's own AE 1.7.99 binary adds
-		// 2 real 8-byte base classes here (not modeled as C++ inheritance in this repo),
-		// shifting every member/offset after them by the same +0x10.
 		static constexpr std::size_t kAE1799AmiiboShift = 0x10;
 
 		[[nodiscard]] inline RUNTIME_DATA& GetRuntimeData() noexcept

--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -290,10 +290,15 @@ namespace RE
             RUNTIME_DATA2_CONTENT
 		};
 
+		// See the base-class-list comment above: the game's own AE 1.7.99 binary adds
+		// 2 real 8-byte base classes here (not modeled as C++ inheritance in this repo),
+		// shifting every member/offset after them by the same +0x10.
+		static constexpr std::size_t kAE1799AmiiboShift = 0x10;
+
 		[[nodiscard]] inline RUNTIME_DATA& GetRuntimeData() noexcept
 		{
 			assert(!REL::Module::IsVR());
-			return REL::RelocateMember<RUNTIME_DATA>(this, REL::AE1799Shift(0x754, 0x10));
+			return REL::RelocateMember<RUNTIME_DATA>(this, REL::AE1799Shift(0x754, kAE1799AmiiboShift));
 		}
 
 		VR_ONLY_POINTER_ACCESSOR(VR_RUNTIME_DATA, GetVRRuntimeData, 0x754);
@@ -303,7 +308,7 @@ namespace RE
 			if SKYRIM_REL_CONSTEXPR (REL::Module::IsVR()) {
 				return REL::RelocateMember<RUNTIME_DATA2>(this, 0x780);
 			}
-			return REL::RelocateMember<RUNTIME_DATA2>(this, REL::AE1799Shift(0x760, 0x10));
+			return REL::RelocateMember<RUNTIME_DATA2>(this, REL::AE1799Shift(0x760, kAE1799AmiiboShift));
 		}
 
 #ifdef ENABLE_SKYRIM_AE
@@ -331,22 +336,22 @@ namespace RE
 #if defined(EXCLUSIVE_SKYRIM_FLAT)
 		[[nodiscard]] BSTEventSink<TESPlayerBowShotEvent>* AsTESPlayerBowShotEventSink() noexcept
 		{
-			return reinterpret_cast<BSTEventSink<TESPlayerBowShotEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x180, 0x10));
+			return reinterpret_cast<BSTEventSink<TESPlayerBowShotEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x180, kAE1799AmiiboShift));
 		}
 
 		[[nodiscard]] BSTEventSink<TESFastTravelEndEvent>* AsTESFastTravelEndEventSink() noexcept
 		{
-			return reinterpret_cast<BSTEventSink<TESFastTravelEndEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x188, 0x10));
+			return reinterpret_cast<BSTEventSink<TESFastTravelEndEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x188, kAE1799AmiiboShift));
 		}
 
 		[[nodiscard]] BSTEventSink<PositionPlayerEvent>* AsPositionPlayerEventSink() noexcept
 		{
-			return reinterpret_cast<BSTEventSink<PositionPlayerEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x190, 0x10));
+			return reinterpret_cast<BSTEventSink<PositionPlayerEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x190, kAE1799AmiiboShift));
 		}
 
 		[[nodiscard]] BSTEventSink<BSScript::StatsEvent>* AsStatsEventSink() noexcept
 		{
-			return reinterpret_cast<BSTEventSink<BSScript::StatsEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x198, 0x10));
+			return reinterpret_cast<BSTEventSink<BSScript::StatsEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x198, kAE1799AmiiboShift));
 		}
 #endif
 

--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -298,7 +298,7 @@ namespace RE
 		[[nodiscard]] inline RUNTIME_DATA& GetRuntimeData() noexcept
 		{
 			assert(!REL::Module::IsVR());
-			return REL::RelocateMember<RUNTIME_DATA>(this, REL::AE1799Shift(0x754, kAE1799AmiiboShift));
+			return REL::RelocateMember<RUNTIME_DATA>(this, REL::VersionShift(0x754, kAE1799AmiiboShift, SKSE::RUNTIME_SSE_1_7_99));
 		}
 
 		VR_ONLY_POINTER_ACCESSOR(VR_RUNTIME_DATA, GetVRRuntimeData, 0x754);
@@ -308,7 +308,7 @@ namespace RE
 			if SKYRIM_REL_CONSTEXPR (REL::Module::IsVR()) {
 				return REL::RelocateMember<RUNTIME_DATA2>(this, 0x780);
 			}
-			return REL::RelocateMember<RUNTIME_DATA2>(this, REL::AE1799Shift(0x760, kAE1799AmiiboShift));
+			return REL::RelocateMember<RUNTIME_DATA2>(this, REL::VersionShift(0x760, kAE1799AmiiboShift, SKSE::RUNTIME_SSE_1_7_99));
 		}
 
 #ifdef ENABLE_SKYRIM_AE
@@ -336,22 +336,22 @@ namespace RE
 #if defined(EXCLUSIVE_SKYRIM_FLAT)
 		[[nodiscard]] BSTEventSink<TESPlayerBowShotEvent>* AsTESPlayerBowShotEventSink() noexcept
 		{
-			return reinterpret_cast<BSTEventSink<TESPlayerBowShotEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x180, kAE1799AmiiboShift));
+			return reinterpret_cast<BSTEventSink<TESPlayerBowShotEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::VersionShift(0x180, kAE1799AmiiboShift, SKSE::RUNTIME_SSE_1_7_99));
 		}
 
 		[[nodiscard]] BSTEventSink<TESFastTravelEndEvent>* AsTESFastTravelEndEventSink() noexcept
 		{
-			return reinterpret_cast<BSTEventSink<TESFastTravelEndEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x188, kAE1799AmiiboShift));
+			return reinterpret_cast<BSTEventSink<TESFastTravelEndEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::VersionShift(0x188, kAE1799AmiiboShift, SKSE::RUNTIME_SSE_1_7_99));
 		}
 
 		[[nodiscard]] BSTEventSink<PositionPlayerEvent>* AsPositionPlayerEventSink() noexcept
 		{
-			return reinterpret_cast<BSTEventSink<PositionPlayerEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x190, kAE1799AmiiboShift));
+			return reinterpret_cast<BSTEventSink<PositionPlayerEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::VersionShift(0x190, kAE1799AmiiboShift, SKSE::RUNTIME_SSE_1_7_99));
 		}
 
 		[[nodiscard]] BSTEventSink<BSScript::StatsEvent>* AsStatsEventSink() noexcept
 		{
-			return reinterpret_cast<BSTEventSink<BSScript::StatsEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x198, kAE1799AmiiboShift));
+			return reinterpret_cast<BSTEventSink<BSScript::StatsEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::VersionShift(0x198, kAE1799AmiiboShift, SKSE::RUNTIME_SSE_1_7_99));
 		}
 #endif
 

--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -293,12 +293,7 @@ namespace RE
 		[[nodiscard]] inline RUNTIME_DATA& GetRuntimeData() noexcept
 		{
 			assert(!REL::Module::IsVR());
-			if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
-				if (REL::Module::get().version().compare(SKSE::RUNTIME_SSE_1_7_99) != std::strong_ordering::less) {
-					return REL::RelocateMember<RUNTIME_DATA>(this, 0x764);
-				}
-			}
-			return REL::RelocateMember<RUNTIME_DATA>(this, 0x754);
+			return REL::RelocateMember<RUNTIME_DATA>(this, REL::AE1799Shift(0x754, 0x10));
 		}
 
 		VR_ONLY_POINTER_ACCESSOR(VR_RUNTIME_DATA, GetVRRuntimeData, 0x754);
@@ -308,12 +303,7 @@ namespace RE
 			if SKYRIM_REL_CONSTEXPR (REL::Module::IsVR()) {
 				return REL::RelocateMember<RUNTIME_DATA2>(this, 0x780);
 			}
-			if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
-				if (REL::Module::get().version().compare(SKSE::RUNTIME_SSE_1_7_99) != std::strong_ordering::less) {
-					return REL::RelocateMember<RUNTIME_DATA2>(this, 0x770);
-				}
-			}
-			return REL::RelocateMember<RUNTIME_DATA2>(this, 0x760);
+			return REL::RelocateMember<RUNTIME_DATA2>(this, REL::AE1799Shift(0x760, 0x10));
 		}
 
 #ifdef ENABLE_SKYRIM_AE
@@ -341,46 +331,22 @@ namespace RE
 #if defined(EXCLUSIVE_SKYRIM_FLAT)
 		[[nodiscard]] BSTEventSink<TESPlayerBowShotEvent>* AsTESPlayerBowShotEventSink() noexcept
 		{
-			std::uintptr_t offset = 0x180;
-			if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
-				if (REL::Module::get().version().compare(SKSE::RUNTIME_SSE_1_7_99) != std::strong_ordering::less) {
-					offset = 0x190;
-				}
-			}
-			return reinterpret_cast<BSTEventSink<TESPlayerBowShotEvent>*>(reinterpret_cast<std::uintptr_t>(this) + offset);
+			return reinterpret_cast<BSTEventSink<TESPlayerBowShotEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x180, 0x10));
 		}
 
 		[[nodiscard]] BSTEventSink<TESFastTravelEndEvent>* AsTESFastTravelEndEventSink() noexcept
 		{
-			std::uintptr_t offset = 0x188;
-			if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
-				if (REL::Module::get().version().compare(SKSE::RUNTIME_SSE_1_7_99) != std::strong_ordering::less) {
-					offset = 0x198;
-				}
-			}
-			return reinterpret_cast<BSTEventSink<TESFastTravelEndEvent>*>(reinterpret_cast<std::uintptr_t>(this) + offset);
+			return reinterpret_cast<BSTEventSink<TESFastTravelEndEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x188, 0x10));
 		}
 
 		[[nodiscard]] BSTEventSink<PositionPlayerEvent>* AsPositionPlayerEventSink() noexcept
 		{
-			std::uintptr_t offset = 0x190;
-			if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
-				if (REL::Module::get().version().compare(SKSE::RUNTIME_SSE_1_7_99) != std::strong_ordering::less) {
-					offset = 0x1A0;
-				}
-			}
-			return reinterpret_cast<BSTEventSink<PositionPlayerEvent>*>(reinterpret_cast<std::uintptr_t>(this) + offset);
+			return reinterpret_cast<BSTEventSink<PositionPlayerEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x190, 0x10));
 		}
 
 		[[nodiscard]] BSTEventSink<BSScript::StatsEvent>* AsStatsEventSink() noexcept
 		{
-			std::uintptr_t offset = 0x198;
-			if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
-				if (REL::Module::get().version().compare(SKSE::RUNTIME_SSE_1_7_99) != std::strong_ordering::less) {
-					offset = 0x1A8;
-				}
-			}
-			return reinterpret_cast<BSTEventSink<BSScript::StatsEvent>*>(reinterpret_cast<std::uintptr_t>(this) + offset);
+			return reinterpret_cast<BSTEventSink<BSScript::StatsEvent>*>(reinterpret_cast<std::uintptr_t>(this) + REL::AE1799Shift(0x198, 0x10));
 		}
 #endif
 

--- a/include/REL/RuntimeDataAccessors.h
+++ b/include/REL/RuntimeDataAccessors.h
@@ -12,17 +12,12 @@ namespace REL
 	/**
 	 * Applies the byte/slot shift required when a Skyrim runtime update inserts an
 	 * additional base class/vtable slot, pushing every member or virtual function
-	 * declared after it forward by a fixed amount on affected classes on builds at
-	 * or above a_threshold. AE 1.7.99 is the only version boundary that currently
-	 * needs this (see SKSE::RUNTIME_SSE_1_7_99 callers), but Bethesda has done this
-	 * kind of mid-stream base-class insertion before (the SE/AE 1.6.629 boundary
-	 * itself) and may again -- this is not 1.7.99-specific.
+	 * declared after it forward by a fixed amount on builds at or above a_threshold.
 	 *
 	 * <p>
-	 * Neither a_delta nor a_threshold has a default -- both vary per class/version
-	 * (a pointer-sized member shift is 8 bytes; a virtual function slot index shifts
-	 * by however many slots were inserted, e.g. 1, 2, or 6) and must be confirmed
-	 * per call site rather than assumed.
+	 * Neither a_delta nor a_threshold has a default -- both are per-class RE facts
+	 * (a member shift is a byte count, a vtable slot index shifts by however many
+	 * slots were inserted) and must be confirmed per call site rather than assumed.
 	 * </p>
 	 */
 	[[nodiscard]] SKYRIM_REL std::size_t VersionShift(std::size_t a_offset, std::size_t a_delta, REL::Version a_threshold) noexcept

--- a/include/REL/RuntimeDataAccessors.h
+++ b/include/REL/RuntimeDataAccessors.h
@@ -1,10 +1,30 @@
 #pragma once
 
 #include <cassert>
+#include <cstddef>
 #include <type_traits>
 
 #include "REL/Relocation.h"
 #include "SKSE/Version.h"
+
+namespace REL
+{
+	/**
+	 * Applies the byte/slot shift required on Skyrim AE 1.7.99+, which inserted an
+	 * additional base class/vtable slot that pushes every member or virtual function
+	 * declared after it forward by a fixed amount on affected classes.
+	 *
+	 * <p>
+	 * a_delta defaults to 8 (a pointer-sized member shift); pass a smaller delta
+	 * (e.g. 1 or 2) for virtual function slot indices, which shift by slot count,
+	 * not bytes.
+	 * </p>
+	 */
+	[[nodiscard]] SKYRIM_REL std::size_t AE1799Shift(std::size_t a_offset, std::size_t a_delta = 8) noexcept
+	{
+		return REL::Module::IsAtLeast(SKSE::RUNTIME_SSE_1_7_99) ? a_offset + a_delta : a_offset;
+	}
+}
 
 // Helper macros for generating runtime data accessor functions.
 // These reduce boilerplate for common patterns across ~160+ accessor function pairs.

--- a/include/REL/RuntimeDataAccessors.h
+++ b/include/REL/RuntimeDataAccessors.h
@@ -15,12 +15,13 @@ namespace REL
 	 * declared after it forward by a fixed amount on affected classes.
 	 *
 	 * <p>
-	 * a_delta defaults to 8 (a pointer-sized member shift); pass a smaller delta
-	 * (e.g. 1 or 2) for virtual function slot indices, which shift by slot count,
-	 * not bytes.
+	 * a_delta has no default -- it varies per class (a pointer-sized member shift is
+	 * 8 bytes; a virtual function slot index shifts by however many slots were
+	 * inserted, e.g. 1, 2, or 6) and must be confirmed per call site rather than
+	 * assumed.
 	 * </p>
 	 */
-	[[nodiscard]] SKYRIM_REL std::size_t AE1799Shift(std::size_t a_offset, std::size_t a_delta = 8) noexcept
+	[[nodiscard]] SKYRIM_REL std::size_t AE1799Shift(std::size_t a_offset, std::size_t a_delta) noexcept
 	{
 		return REL::Module::IsAtLeast(SKSE::RUNTIME_SSE_1_7_99) ? a_offset + a_delta : a_offset;
 	}

--- a/include/REL/RuntimeDataAccessors.h
+++ b/include/REL/RuntimeDataAccessors.h
@@ -10,20 +10,24 @@
 namespace REL
 {
 	/**
-	 * Applies the byte/slot shift required on Skyrim AE 1.7.99+, which inserted an
-	 * additional base class/vtable slot that pushes every member or virtual function
-	 * declared after it forward by a fixed amount on affected classes.
+	 * Applies the byte/slot shift required when a Skyrim runtime update inserts an
+	 * additional base class/vtable slot, pushing every member or virtual function
+	 * declared after it forward by a fixed amount on affected classes on builds at
+	 * or above a_threshold. AE 1.7.99 is the only version boundary that currently
+	 * needs this (see SKSE::RUNTIME_SSE_1_7_99 callers), but Bethesda has done this
+	 * kind of mid-stream base-class insertion before (the SE/AE 1.6.629 boundary
+	 * itself) and may again -- this is not 1.7.99-specific.
 	 *
 	 * <p>
-	 * a_delta has no default -- it varies per class (a pointer-sized member shift is
-	 * 8 bytes; a virtual function slot index shifts by however many slots were
-	 * inserted, e.g. 1, 2, or 6) and must be confirmed per call site rather than
-	 * assumed.
+	 * Neither a_delta nor a_threshold has a default -- both vary per class/version
+	 * (a pointer-sized member shift is 8 bytes; a virtual function slot index shifts
+	 * by however many slots were inserted, e.g. 1, 2, or 6) and must be confirmed
+	 * per call site rather than assumed.
 	 * </p>
 	 */
-	[[nodiscard]] SKYRIM_REL std::size_t AE1799Shift(std::size_t a_offset, std::size_t a_delta) noexcept
+	[[nodiscard]] SKYRIM_REL std::size_t VersionShift(std::size_t a_offset, std::size_t a_delta, REL::Version a_threshold) noexcept
 	{
-		return REL::Module::IsAtLeast(SKSE::RUNTIME_SSE_1_7_99) ? a_offset + a_delta : a_offset;
+		return REL::Module::IsAtLeast(a_threshold) ? a_offset + a_delta : a_offset;
 	}
 }
 


### PR DESCRIPTION
Precursor to #343. `BSSaveDataSystemUtility.h`, `BSSystemUtility.h`, `HeldStateHandler.h`, `MenuEventHandler.h`, and `PlayerInputHandler.h` each independently define/undef a local `AE1799_SLOT_SHIFT` macro to branch vtable slot indices around Skyrim AE 1.7.99's added base class. `PlayerCharacter.h` has a near-identical `AE1799_SHIFT` macro with the exact `#undef`-before-cross-TU-use footgun that #342/#343 fixed. `SkyrimVM.h` repeats the same `if AE && >=version, offset += delta` branch inline 6 more times (no macro, just copy-pasted).

Adds `REL::VersionShift(offset, delta, threshold)` in `include/REL/RuntimeDataAccessors.h` (the existing home for this kind of version-branching accessor helper) and migrates all of the above onto it. `threshold` and `delta` are both required (no defaults): a shift's version boundary and magnitude are independent RE facts per class, not properties of the helper, and no single default would be safe for most callers. Deltas are named constants at each call site (`kAE1799AddedVFuncCount`, `kAE1799AmiiboShift`) rather than bare literals, per this repo's magic-number convention -- a missing/wrong delta is now a compile error, not a silently wrong offset.

`1.7.99` is the only threshold any current call site needs, but the helper isn't named or hardcoded to it -- Bethesda has done this exact kind of mid-stream base-class insertion before (the SE/AE 1.6.629 boundary) and may again, and a future occurrence can now reuse this instead of hand-rolling another bespoke branch.

Verified with clean builds of `debug-msvc-vcpkg-ae`, `debug-msvc-vcpkg-vr`, and `debug-clang-cl-vcpkg-flatrim` (the only configured preset that compiles the `EXCLUSIVE_SKYRIM_FLAT`-gated `SkyrimVM.h` accessors) after each change.

Once merged, #343 will rebase onto `ng` with `PlayerCharacter.h` also adopting `REL::VersionShift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PRivRXgvTbSv4ukN1jewN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for virtual function dispatch across supported Skyrim runtime versions, including AE 1.7.99 and later.
  - Corrected runtime-dependent handling for input, menu, held-state, save-data, and scripting systems.

- **Refactor**
  - Consolidated version-aware offset handling for more consistent behavior across runtime versions.
  - Preserved existing runtime data access behavior while simplifying version checks.
  - Added centralized runtime version handling for more reliable compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->