### PR TITLE
feat(rex): add a REX::W32 to SDK type bridge

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -2060,6 +2060,7 @@ set(SOURCES
 	include/REX/W32/ADVAPI32.h
 	include/REX/W32/BASE.h
 	include/REX/W32/BCRYPT.h
+	include/REX/W32/Bridge.h
 	include/REX/W32/COM.h
 	include/REX/W32/COMPTR.h
 	include/REX/W32/D3D.h

--- a/include/REX/W32/Bridge.h
+++ b/include/REX/W32/Bridge.h
@@ -1,0 +1,78 @@
+#pragma once
+
+// CommonLib first, SDK second -- REX/W32/BASE.h errors if the Windows API was
+// included first.
+#include "REX/W32/D3D11.h"
+
+#include <d3d11.h>
+#include <type_traits>
+
+// Deliberately absent from REX/W32.h: this is the one REX header that includes
+// the SDK, so a consumer opts in only where it already links d3d11.
+
+namespace REX::W32
+{
+	namespace detail
+	{
+		template <class T>
+		struct RealOf
+		{
+			static_assert(!std::is_same_v<T, T>, "no REX::W32 <-> SDK pairing registered for this type -- add a REX_W32_PAIR entry in REX/W32/Bridge.h");
+		};
+		template <class T>
+		struct W32Of
+		{
+			static_assert(!std::is_same_v<T, T>, "no REX::W32 <-> SDK pairing registered for this type -- add a REX_W32_PAIR entry in REX/W32/Bridge.h");
+		};
+
+		// clang-format off
+#define REX_W32_PAIR(Real, W32Type)                             \
+	template <> struct RealOf<Real> { using type = Real; };     \
+	template <> struct RealOf<W32Type> { using type = Real; };  \
+	template <> struct W32Of<Real> { using type = W32Type; };   \
+	template <> struct W32Of<W32Type> { using type = W32Type; };
+		// clang-format on
+
+		REX_W32_PAIR(::ID3D11View, ID3D11View)
+		REX_W32_PAIR(::ID3D11Resource, ID3D11Resource)
+		REX_W32_PAIR(::ID3D11Texture2D, ID3D11Texture2D)
+		REX_W32_PAIR(::ID3D11ShaderResourceView, ID3D11ShaderResourceView)
+		REX_W32_PAIR(::ID3D11RenderTargetView, ID3D11RenderTargetView)
+		REX_W32_PAIR(::ID3D11DepthStencilView, ID3D11DepthStencilView)
+		REX_W32_PAIR(::ID3D11UnorderedAccessView, ID3D11UnorderedAccessView)
+		REX_W32_PAIR(::D3D11_TEXTURE2D_DESC, D3D11_TEXTURE2D_DESC)
+		REX_W32_PAIR(::D3D11_SHADER_RESOURCE_VIEW_DESC, D3D11_SHADER_RESOURCE_VIEW_DESC)
+		REX_W32_PAIR(::D3D11_RENDER_TARGET_VIEW_DESC, D3D11_RENDER_TARGET_VIEW_DESC)
+		REX_W32_PAIR(::D3D11_DEPTH_STENCIL_VIEW_DESC, D3D11_DEPTH_STENCIL_VIEW_DESC)
+		REX_W32_PAIR(::D3D11_UNORDERED_ACCESS_VIEW_DESC, D3D11_UNORDERED_ACCESS_VIEW_DESC)
+		REX_W32_PAIR(::GUID, GUID)
+		REX_W32_PAIR(const ::GUID, const GUID)
+
+		REX_W32_PAIR(::ID3D11Resource*, ID3D11Resource*)
+		REX_W32_PAIR(::ID3D11Texture2D*, ID3D11Texture2D*)
+		REX_W32_PAIR(::ID3D11ShaderResourceView*, ID3D11ShaderResourceView*)
+		REX_W32_PAIR(::ID3D11RenderTargetView*, ID3D11RenderTargetView*)
+		REX_W32_PAIR(::ID3D11UnorderedAccessView*, ID3D11UnorderedAccessView*)
+#undef REX_W32_PAIR
+	}
+
+	template <class T>
+	[[nodiscard]] auto* AsReal(T* a_ptr) noexcept
+	{
+		return reinterpret_cast<typename detail::RealOf<T>::type*>(a_ptr);
+	}
+
+	template <class T>
+	[[nodiscard]] auto* AsW32(T* a_ptr) noexcept
+	{
+		return reinterpret_cast<typename detail::W32Of<T>::type*>(a_ptr);
+	}
+
+	// Explicit both-type form for a source that is type-erased (e.g. a void* an
+	// engine hook fills in), where there is nothing to deduce from.
+	template <class To, class From>
+	[[nodiscard]] To* CastTo(From* a_ptr) noexcept
+	{
+		return reinterpret_cast<To*>(a_ptr);
+	}
+}


### PR DESCRIPTION
## Summary
Adds `REX::W32::AsReal`/`AsW32`, a small bridge between `REX::W32`'s D3D11 reimplementation and the real Windows SDK types, in a new header (`REX/W32/Bridge.h`).

`REX::W32` reimplements the D3D11 interfaces so CommonLib itself needs no Windows SDK headers. That leaves every consumer that both uses CommonLib's `RE::` types *and* calls the real D3D11 API (nearly any renderer plugin) writing its own `reinterpret_cast` at each boundary point -- open-shaders alone has 357 of them across 63 files ([alandtse/open-shaders#590](https://github.com/alandtse/open-shaders/pull/590)).

- `detail::RealOf<T>`/`W32Of<T>` pair each SDK type with its `REX::W32` counterpart via a small trait table (`REX_W32_PAIR` macro, one line per type). `AsReal`/`AsW32` deduce the target from the argument, so a call site names no type: `REX::W32::AsReal(rtData.texture)`, `REX::W32::AsW32(&texDesc)`.
- `CastTo<To>` keeps an explicit-target form for the rare source that is type-erased (a `void*` an engine hook fills in), where there is nothing to deduce from.
- All three are `reinterpret_cast`, so no code is generated; this is purely a type-system convenience.
- An unresolved-type call site is a compile error naming the missing pairing (`static_assert` with a message pointing at this file), not a silent wrong cast.

`Bridge.h` is deliberately **not** added to the `REX/W32.h` aggregate: it is the one REX header that includes `<d3d11.h>`, so a consumer opts in explicitly, only where they already link the SDK. Everyone else is unaffected.

Verified `CommonLib`'s own `BASE.h` guard (`#error Windows API detected...`) requires CommonLib's headers to precede the SDK in a translation unit -- confirmed live that `<d3d11.h>` itself defines `_INC_WINAPIFAMILY`, so `Bridge.h` includes `REX/W32/D3D11.h` before `<d3d11.h>` to stay safe regardless of what a consumer includes first.

Stacked on #332 (this branch's base). No behavior change to any existing type or function.

## Test plan
- [x] Standalone syntax check (both directions, the deducing trait table, and `CastTo`) compiles clean under `/W4 /permissive-` with the CommonLib include path.
- [x] Exercised for real by [open-shaders#590](https://github.com/alandtse/open-shaders/pull/590), which pins this branch's head commit and re-exports these three names for its own 357 call sites -- `BuildPR.bat` (multi-runtime `SKYRIM_CROSS_VR`) builds clean, zero errors/warnings, and its Catch2 suite (153 cases / 1649 assertions) passes.
- [x] Not added to `REX/W32.h`, so every existing CommonLib consumer's include graph is unchanged; the full `build-all-presets` suite (SE/AE/VR/Flatrim/All) is unaffected since nothing new is pulled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows interoperability support for converting between Windows SDK Direct3D 11 types and their REX equivalents.
  * Added type-safe conversion utilities for supported Direct3D 11 resources, views, descriptions, GUIDs, and pointer forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->